### PR TITLE
Move the package under the `@ansible` scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ansible-language-server",
+  "name": "@ansible/ansible-language-server",
   "publisher": "RedHat Inc.",
   "displayName": "Ansible",
   "description": "Ansible language server",


### PR DESCRIPTION
On the team call and in private discussions, we've decided to republish this dist under an `@ansible` org that we apparently have access to.
The only thing undecided is whether we want `@ansible/ansible-language-server` or `@ansible/language-server`.

Most of the folks agreed on the former but since @relrod and @cidrblock are on PTO, they didn't get to vote and so this PR **mustn't be merged until we get approvals** or other opinions from them. This is why I'm marking this as a draft for now but everybody else should feel free to leave reviews meanwhile (although, it's optional).