### PR TITLE
Fix path to the YAML fixtures in tests

### DIFF
--- a/test/utils/yaml.test.ts
+++ b/test/utils/yaml.test.ts
@@ -16,7 +16,7 @@ import {
 
 async function getYamlDoc(yamlFile: string) {
   const yaml = await fs.readFile(
-    path.resolve('server', 'src', 'test', 'data', 'utils', 'yaml', yamlFile),
+    path.resolve('test', 'data', 'utils', 'yaml', yamlFile),
     {
       encoding: 'utf8',
     }


### PR DESCRIPTION
The currently checked in the repo test attempts accessing YAML files under the wrong path with a prefix of `server/src/` which fails. This patch removes the incorrect chunk of the path making the tests pass.

This must be merged before https://github.com/ansible/ansible-language-server/pull/18.