### PR TITLE
chore: Add "prepare" to scripts section of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "watch": "tsc --watch -p .",
     "test": "mocha --require ts-node/register './test/**/*.ts'",
     "build": "yarn clean && yarn compile",
+    "prepare": "yarn clean && yarn compile",
     "check-dependencies": "node ./scripts/check-dependencies.js"
   },
   "all": true


### PR DESCRIPTION
## Description

I thought it would be useful to add "prepare" so that `yarn` or `yarn install` alone would also build.

If you have not intentionally set "prepare", Please close this PR. 🙇

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/133533802-95788455-6286-4cc8-aabe-1a9613733e57.mp4
