### PR TITLE
chore: enforce npm and node requirements

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+engine-strict=true
+fund=false
+package-lock=true

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "icon": "icon.png",
   "engines": {
-    "node": "*"
+    "node": ">=12.0",
+    "npm": ">=7.11.2"
   },
   "bin": {
     "ansible-language-server": "./bin/ansible-language-server"


### PR DESCRIPTION
Require relatively modern `node>=12` and `npm>7.11.2` in order to avoid bugs and different behaviors during build and testing.

`npm 7.11.2` is the version currently shipping with fedora 34.

That is in sync with requirements that we already use for
vscode-ansible extension. These requirements are build/test specific
and do not affect the runtime.

Prevents bug where older npm would mess the format of `package-lock.json` file. As CI is not setup yet, it is recommended to test it locally first.

Originally included in #17