### PR TITLE
chore: avoid duplicate builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build
 
+    # avoid duplicate builds for internal pull-requests
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'ansible/ansible-language-server'
     runs-on: Ubuntu-latest
 
     steps:


### PR DESCRIPTION
Sorts duplicate jobs running for internal pull requests while
still running build.

This approach has the advantage that those that fork our repository
will still run jobs on their own repositories before they
create a pull request.

Reference: https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012/5?u=ssbarnea
