### PR TITLE
Add eslint execution to linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,22 @@ repos:
 
       - id: debug-statements
         language_version: python3
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v7.30.0
+    hooks:
+      - id: eslint
+        args:
+          - --fix
+          - --max-warnings
+          - "0"
+        additional_dependencies:
+          - "@typescript-eslint/eslint-plugin"
+          - "@typescript-eslint/parser"
+          - eslint
+          - eslint-plugin-prettier
+          - eslint-config-prettier
+          - prettier
+          - typescript
+          - typescript-eslint
+        files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
+        types: [file]

--- a/scripts/.eslintrc.js
+++ b/scripts/.eslintrc.js
@@ -17,9 +17,15 @@ module.exports = {
   ],
   rules: {
     'prettier/prettier': 'error',
-    '@typescript-eslint/no-use-before-define': ['error', { functions: false, classes: false }],
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      { functions: false, classes: false },
+    ],
     '@typescript-eslint/no-unused-vars': ['warn'],
-    '@typescript-eslint/explicit-function-return-type': [1, { allowExpressions: true }],
+    '@typescript-eslint/explicit-function-return-type': [
+      1,
+      { allowExpressions: true },
+    ],
     'eol-last': ['error'],
     'space-infix-ops': ['error', { int32Hint: false }],
     'no-multi-spaces': ['error', { ignoreEOLComments: true }],

--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -14,7 +14,9 @@ for (const dep in dependencies) {
   if (Object.prototype.hasOwnProperty.call(dependencies, dep)) {
     const version = dependencies[dep];
     if (version === 'next') {
-      console.error(`Dependency ${dep} has "${version}" version, please change it to fixed version`);
+      console.error(
+        `Dependency ${dep} has "${version}" version, please change it to fixed version`
+      );
       exit(1);
     }
   }


### PR DESCRIPTION
While we had eslint configured inside the repository, there was
not job ensuring that it did run. This change adds eslint as part
of our existing lint job (pre-commit).

Only two files were automatically reformatted by this change.