### PR TITLE
Update the default settings value for using FQCN

### DIFF
--- a/src/services/settingsManager.ts
+++ b/src/services/settingsManager.ts
@@ -13,7 +13,7 @@ export class SettingsManager {
     new Map();
 
   private defaultSettings: ExtensionSettings = {
-    ansible: { path: 'ansible', useFullyQualifiedCollectionNames: false },
+    ansible: { path: 'ansible', useFullyQualifiedCollectionNames: true },
     ansibleLint: { enabled: true, path: 'ansible-lint', arguments: '' },
     python: { interpreterPath: '', activationScript: '' },
   };


### PR DESCRIPTION
This is the related PR: https://github.com/ansible/vscode-ansible/pull/196 .

> To ensure best practices, the default value for ansible.ansible.useFullyQualifiedCollectionNames is set to true.
That means, by default, the auto-completion in the editor would produce FQCNs for module names.

This PR is for syncing the default settings value in both the repositories, i.e., client and server.
