### PR TITLE
Check that module paths are directories before globbing them

### DIFF
--- a/src/utils/docsFinder.ts
+++ b/src/utils/docsFinder.ts
@@ -17,6 +17,9 @@ export async function findDocumentation(
     | 'builtin_doc_fragment'
     | 'collection_doc_fragment'
 ): Promise<IModuleMetadata[]> {
+  if (!fs.existsSync(dir) || fs.lstatSync(dir).isFile()) {
+    return [];
+  }
   let files;
   switch (kind) {
     case 'builtin':
@@ -74,6 +77,9 @@ export async function findPluginRouting(
   kind: 'builtin' | 'collection'
 ): Promise<IPluginRoutingByCollection> {
   const pluginRouting = new Map<string, IPluginRoutesByType>();
+  if (!fs.existsSync(dir) || fs.lstatSync(dir).isFile()) {
+    return pluginRouting;
+  }
   let files;
   switch (kind) {
     case 'builtin':


### PR DESCRIPTION
I found that easy-install had added a .egg file to my python path, which then caused the language server to barf when it tried to glob "my_file.egg/**/whatever". This just adds an early return for when the path exists and is found to be a file in the two cases where it seems to matter.