### PR TITLE
Fix pre-commit.ci job

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,9 @@ ci:
     chore: auto fixes from pre-commit.com hooks
 
     for more information, see https://pre-commit.ci
+  skip:
+    # https://github.com/pre-commit-ci/issues/issues/55
+    - npm-ci
 repos:
   - repo: local
     hooks:


### PR DESCRIPTION
As pre-commit.ci service does not allow access to npm we skip
this hook on it. We still run full suite in our own job.