### PR TITLE
Rewrite the `build-syntaxes` script in pure Python 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,16 @@ ci:
 repos:
   - repo: local
     hooks:
+      - id: build-syntaxes
+        name: Check the syntax files are in sync
+        entry: python scripts/build-syntaxes
+        language: python
+        pass_filenames: false
+        always_run: true
+        additional_dependencies:
+          - click
+          - lxml
+          - pyparsing
       - id: npm-ci
         name: Run 'npm ci' to ensure deps and versions are correct
         entry: >-

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "scripts": {
     "clean": "rimraf out/server && rimraf lib",
     "compile": "tsc -p .",
-    "lint": "npm ci && ./scripts/build-syntaxes && pre-commit run -a",
+    "lint": "npm ci && pre-commit run -a",
     "watch": "tsc --watch -p .",
     "test": "mocha --require ts-node/register './test/**/*.ts'",
     "check-dependencies": "node ./scripts/check-dependencies.js"

--- a/scripts/build-syntaxes
+++ b/scripts/build-syntaxes
@@ -1,9 +1,14 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env python
+import glob
+import os
+import sys
+import subprocess
 
-for SRC in syntaxes/ansible/*.plist; do
-
-    DST=$(basename "$(basename "$SRC" .plist)")
-    python3 syntaxes/plist2xml.py "$SRC" "syntaxes/ansible/generated/$DST"
-
-done
+for src in glob.glob("syntaxes/ansible/*.plist"):
+    dst = os.path.splitext(os.path.basename(src))[0]
+    cmd = [sys.executable, "syntaxes/plist2xml.py", src, f"syntaxes/ansible/generated/{dst}"]
+    print(f"Running: {' '.join(cmd)}")
+    subprocess.run(
+        cmd,
+        check=True
+        )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,4 @@
+click
 lxml
 pre-commit
+pyparsing


### PR DESCRIPTION
Drops use of bash in build-syntaxes script and runs it as just another
pre-commit hook. This also takes care of installing required
dependencies and virtualenv management.

Note: the change from double quoted strings to single quoted is done automatically on file-save by prettier, which is already recommended by this repo. Their inclusion is not accidental.