### PR TITLE
Enable release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,54 @@
+# Format and labels used aim to match those used by Ansible project
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "Major Changes"
+    labels:
+      - "major" # c6476b
+  - title: "Minor Changes"
+    labels:
+      - "feature" # 006b75
+      - "minor"
+  - title: "Bugfixes"
+    labels:
+      - "bug" # fbca04
+      - "patch"
+exclude-labels:
+  - "skip-changelog"
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+      - "feature"
+  patch:
+    labels:
+      - "patch"
+      - "bug"
+  default: patch
+autolabeler:
+  # converts commitlint/conventionalcommits format into labels that
+  # release-drafter can use to produce the release notes.
+  # https://github.com/conventional-changelog/commitlint#what-is-commitlint
+  # External contributors do not have the ability to change labels but by
+  # using conventional commits/pr titles the labels are automatially updated.
+  - label: "skip-changelog"
+    title:
+      - "/(chore|ci|build|style|test)/i"
+  - label: "bug"
+    title:
+      - "/(fix|revert|refactor|perf|docs)/i"
+  - label: "feature"
+    title:
+      - "/feat/i"
+  - label: "major"
+    title:
+      - "/!:/"
+    body:
+      - "/BREAKING CHANGE/"
+template: |
+  $CHANGES
+
+  Kudos goes to: $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: release-drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+      - "releases/**"
+      - "stable/**"
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-20.04
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Activates release drafter using the same config we have on the
other devtools projects. This should help us get a better view
of what will be included in the next release and which version
number it should use.
