### PR TITLE
chore: reduce length of notification while pulling images

### DIFF
--- a/src/utils/imagePuller.ts
+++ b/src/utils/imagePuller.ts
@@ -45,9 +45,9 @@ export class ImagePuller {
         const pullCommand = `${this._containerEngine} pull ${this._containerImage}`;
         if (progressTracker) {
           progressTracker.begin(
-            'image-puller',
+            'execution-environment',
             undefined,
-            `Pulling image '${this._containerImage}'`
+            'Pulling image...'
           );
         }
         child_process.execSync(pullCommand, {


### PR DESCRIPTION
*  Based on feedback from Ansible Devtools team members
   the PR removes the name of the container image from
   progress tracker notification message to reduce
   the length of the message thus trying to make it less distracting :)