### PR TITLE
fix: initialise executionEnvironment service only when enabled

### DIFF
--- a/src/services/executionEnvironment.ts
+++ b/src/services/executionEnvironment.ts
@@ -29,6 +29,9 @@ export class ExecutionEnvironment {
       const settings = await this.context.documentSettings.get(
         this.context.workspaceFolder.uri
       );
+      if (!settings.executionEnvironment.enabled) {
+        return;
+      }
       this._container_image = settings.executionEnvironment.image;
       this._container_engine = settings.executionEnvironment.containerEngine;
       if (this._container_engine === 'auto') {

--- a/src/utils/commandRunner.ts
+++ b/src/utils/commandRunner.ts
@@ -31,7 +31,6 @@ export class CommandRunner {
     let executablePath: string;
     let command: string;
     let runEnv: NodeJS.ProcessEnv | undefined;
-    const executionEnvironment = await this.context.executionEnvironment;
     const isEEEnabled = this.settings.executionEnvironment.enabled;
     const interpreterPath = isEEEnabled
       ? 'python3'
@@ -52,8 +51,9 @@ export class CommandRunner {
         interpreterPath,
         this.settings.python.activationScript
       );
-    } // prepare command executin env run
-    else {
+    } else {
+      // prepare command executing env run
+      const executionEnvironment = await this.context.executionEnvironment;
       command = executionEnvironment.wrapContainerArgs(`${executable} ${args}`);
       runEnv = undefined;
     }


### PR DESCRIPTION
*  Fetch execution environment context in CommandRunner class
   only when `ansible.executionEnvironment.enabled` is set
   to `true`
*  Update initialise method of executionEnvironment service
   to return early in case `ansible.executionEnvironment.enabled`
   is set to false