### PR TITLE
chore: use same version of eslint on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
       - id: debug-statements
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v7.30.0
+    rev: v7.32.0
     hooks:
       - id: eslint
         args:
@@ -77,7 +77,7 @@ repos:
         additional_dependencies:
           - "@typescript-eslint/eslint-plugin"
           - "@typescript-eslint/parser"
-          - eslint
+          - eslint@v7.32.0
           - eslint-plugin-prettier
           - eslint-config-prettier
           - prettier

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@typescript-eslint/eslint-plugin": "^4.28.3",
         "@typescript-eslint/parser": "^4.28.3",
         "chai": "^4.3.4",
-        "eslint": "^7.30.0",
+        "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "mocha": "^8.4.0",
         "prettier": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
     "chai": "^4.3.4",
-    "eslint": "^7.30.0",
+    "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "mocha": "^8.4.0",
     "prettier": "^2.4.1",


### PR DESCRIPTION
Fixes bug in pre-commit config mentioned in https://github.com/pre-commit-ci/issues/issues/96
