### PR TITLE
chore: separate release workflow from testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ name: CI
 on:
   pull_request:
   push:
+  workflow_call:
 
 jobs:
 
@@ -103,51 +104,4 @@ jobs:
       run: npm ci
     - name: Run testing against the Git checkout
       run: npm test
-
-  publish:
-    environment: release
-    needs:
-    - test
-
-    runs-on: Ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version:
-        - 16.x
-
-    steps:
-    - name: Fetch the GHA artifact with the package tarball
-      uses: actions/upload-artifact@v2
-      with:
-        name: npm-package-tarball
-        path: .
-
-    - name: >-
-        Set up NodeJS ${{ matrix.node-version }}
-        with the global NPM registry
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: https://registry.npmjs.org
-    - name: >-
-        Publish the prebuilt and tested package
-        to public NPM Registry
-      run: npm publish ansible-ansible-language-server-*.tgz
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-    - name: >-
-        Set up NodeJS ${{ matrix.node-version }}
-        with the GitHub Packages NPM registry
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: https://npm.pkg.github.com
-    - name: >-
-        Publish the prebuilt and tested package
-        to GitHub Packages NPM Registry
-      run: npm publish ansible-ansible-language-server-*.tgz
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: release
+
+on:
+  create:
+    tags:
+
+jobs:
+  before-release:
+    uses: ansible/ansible-language-server/.github/workflows/ci.yml@main
+
+  release:
+    name: release ${{ github.event.ref }}
+    environment: release
+    needs:
+    - before-release
+
+    runs-on: Ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version:
+        - 16.x
+
+    steps:
+    - name: Fetch the GHA artifact with the package tarball
+      uses: actions/upload-artifact@v2
+      with:
+        name: npm-package-tarball
+        path: .
+
+    - name: >-
+        Set up NodeJS ${{ matrix.node-version }}
+        with the global NPM registry
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: https://registry.npmjs.org
+    - name: >-
+        Publish the prebuilt and tested package
+        to public NPM Registry
+      run: npm publish ansible-ansible-language-server-*.tgz
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: >-
+        Set up NodeJS ${{ matrix.node-version }}
+        with the GitHub Packages NPM registry
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: https://npm.pkg.github.com
+    - name: >-
+        Publish the prebuilt and tested package
+        to GitHub Packages NPM Registry
+      run: npm publish ansible-ansible-language-server-*.tgz
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Moves the publishing out of ci.yml workflow into a release one. This
will avoid running and failing publish on each pull-request.

Now release will run only on tag pushes, which includes releases
made using github interface. For safety reasons we still run the
tests before doing the effective publication, so we avoid making
a release that does not pass testing.

An example on how the workflow run will look after can be seen at https://github.com/ssbarnea/gha-playground/actions/runs/1320622965