### PR TITLE
chore: remove experimental flag from jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,8 +216,6 @@ jobs:
 
     strategy:
       matrix:
-        experimental:
-        - false
         node-version:
         - 16.x
         - 14.x
@@ -226,11 +224,9 @@ jobs:
         - Ubuntu
         - macOS
         include:
-        - experimental: true
-          node-version: 16
+        - node-version: 16
           os: Windows
-        - experimental: true
-          node-version: 12
+        - node-version: 12
           os: Windows
 
     continue-on-error: >-


### PR DESCRIPTION
As we refactored our jobs to pass on all platforms we no longer
need the experimental flag.
