### PR TITLE
Fix autocompletion of the builtin modules with EE

### DIFF
--- a/src/services/executionEnvironment.ts
+++ b/src/services/executionEnvironment.ts
@@ -313,9 +313,11 @@ export class ExecutionEnvironment {
         asyncExec(copyCommand, {
           encoding: 'utf-8',
         });
+
         updatedHostDocPath.push(destPath);
       }
     });
+
     return updatedHostDocPath;
   }
 


### PR DESCRIPTION
Fixes https://github.com/ansible/vscode-ansible/issues/265

*  Update copy plugins logic from EE to local host to check
   for presence of the complete plugin folder path instead
   of the base of host cache path.