### PR TITLE
Update plugin doc cache validate logic for execution environment

### DIFF
--- a/src/services/executionEnvironment.ts
+++ b/src/services/executionEnvironment.ts
@@ -13,6 +13,7 @@ export class ExecutionEnvironment {
   private connection: Connection;
   private context: WorkspaceFolderContext;
   private useProgressTracker = false;
+  private successFileMarker = 'SUCCESS'
   private _container_engine: IContainerEngine;
   private _container_image: string;
   private _container_image_id: string;
@@ -118,7 +119,7 @@ export class ExecutionEnvironment {
         return;
       }
 
-      if (fs.existsSync(hostCacheBasePath)) {
+      if (this.isPluginDocCacheValid(hostCacheBasePath)) {
         ansibleConfig.collections_paths = this.updateCachePaths(
           ansibleConfig.collections_paths,
           hostCacheBasePath
@@ -175,6 +176,8 @@ export class ExecutionEnvironment {
           '**/modules'
         );
       }
+      // plugin cache successfully created
+      fs.closeSync(fs.openSync(path.join(hostCacheBasePath, this.successFileMarker), 'w'));
     } catch (error) {
       this.connection.window.showErrorMessage(
         `Exception in ExecutionEnvironment service while fetching docs: ${JSON.stringify(
@@ -333,5 +336,10 @@ export class ExecutionEnvironment {
       }
     });
     return localCachePaths;
+  }
+
+  private isPluginDocCacheValid(hostCacheBasePath: string) {
+    const markerFilePath = path.join(hostCacheBasePath, this.successFileMarker)
+    return true ? fs.existsSync(markerFilePath) : false
   }
 }


### PR DESCRIPTION
*  Add a file marker in the base path
   of local cache after all the plugin
   docs are successfully copied to local
   cache path from within execution environment
*  Add check to update the local cache if `SUCCESS`
   file marker is not present in the path