### PR TITLE
gha: prevent buid from passing if git reports dirty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,9 @@ jobs:
         name: npm-package-tarball
         path: ${{ needs.pre-setup.outputs.tarball-artifact-name }}
 
+    - name: Check if git reports dirty
+      run: git diff --exit-code
+
   # vscode:
   #   uses: .github/workflows/vscode.yml@main
 


### PR DESCRIPTION
This should prevent bugs where what we build is not the tracked
code or divergence between version inside package.json and
package-lock.json
