### PR TITLE
Ensure npm link uses --save

### DIFF
--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -35,7 +35,7 @@ jobs:
           set -ex
           mv vscode-ansible ..
           pushd ../vscode-ansible
-          npm link ../ansible-language-server
+          npm link --save ../ansible-language-server
           npm ls --depth=0 --link=true
           popd
 


### PR DESCRIPTION
To prevent npm install from overriding `npm link` outcomes or getting
errors when running `npm ls` we must be sure we do always add `--save`

Related: https://github.com/npm/cli/issues/2380
