### PR TITLE
Revert invalid change "Avoid git am failure with empty patches (#134)" that breaks the CI safeguards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,14 +314,7 @@ jobs:
         name: npm-package-bump-patch
 
     - name: Apply the version patch
-      # `git am` is unable to apply empty patches and this is what we get
-      # if we already have the correct versions configured.
-      run: >
-        [ -s ${{ needs.pre-setup.outputs.version-patch-name }} ] &&
-        git am ${{ needs.pre-setup.outputs.version-patch-name }}
-        || echo "Empty patch ignored."
-      shell: bash
-
+      run: git am ${{ needs.pre-setup.outputs.version-patch-name }}
     - name: Drop the version patch file
       run: rm -fv ${{ needs.pre-setup.outputs.version-patch-name }}
       shell: bash


### PR DESCRIPTION
This reverts commit fe76efe8ee25de227c0e0939a9d5d05e66d01545.