### PR TITLE
Allow use of Ansible files without a workspace

### DIFF
--- a/src/services/workspaceManager.ts
+++ b/src/services/workspaceManager.ts
@@ -13,6 +13,8 @@ import { DocsLibrary } from './docsLibrary';
 import { ExecutionEnvironment } from './executionEnvironment';
 import { MetadataLibrary } from './metadataLibrary';
 import { SettingsManager } from './settingsManager';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
 
 /**
  * Holds the overall context for the whole workspace.
@@ -73,6 +75,20 @@ export class WorkspaceManager {
         return workspaceFolder;
       }
     }
+    /* *
+    * If control reaches at this point it indicates an individual file is
+    * opened in client without any workspace.
+    * Set the workspace to directory of the file pointed by uri.
+    */
+    const documentFolderPathParts = uri.split(path.sep)
+    documentFolderPathParts.pop()
+    const workspaceFolder: WorkspaceFolder = {
+      'uri': documentFolderPathParts.join(path.sep),
+      'name': documentFolderPathParts[documentFolderPathParts.length - 1]
+    }
+
+    this.connection.console.log(`workspace folder explicitly set to ${URI.parse(workspaceFolder.uri).path}`);
+    return workspaceFolder
   }
 
   public handleWorkspaceChanged(event: WorkspaceFoldersChangeEvent): void {


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-language-server/issues/117

*  If an individual file is opened in client without workspace (in
   case of VSCode) the workspace param in undefined
*  To allow completion to work explicity set the workspace to
   the folder containing the file opened within client.