### PR TITLE
Replace plain text a user handles with roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,30 +27,33 @@ https://github.com/ansible/ansible-language-server/tree/main/docs/changelog-frag
 ### Bugfixes
 
 * Prevented throwing an unhandled exception caused by undefined linter
-  arguments settings (#142) @ssbarnea
+  arguments settings (#142) {user}`ssbarnea`
 * Implemented opening standalone Ansible files that have no workspace
-  associated (#140) @ganeshrn
+  associated (#140) {user}`ganeshrn`
 
 ## v0.3.0 (2021-11-18)
 
 ### Minor Changes
 
-* Added support for nested module options (suboptions) (#116) @tomaciazek
-* Adopted use of `creator-ee` execution environment (#132) @ssbarnea
-* Updated container cleanup logic for execution environment (#111) @ganeshrn
+* Added support for nested module options (suboptions) (#116)
+  {user}`tomaciazek`
+* Adopted use of `creator-ee` execution environment (#132)
+  {user}`ssbarnea`
+* Updated container cleanup logic for execution environment (#111)
+  {user}`ganeshrn`
 
 ### Bugfixes
 
 * Updated plugin doc cache validate logic for execution environment (#109)
-  @ganeshrn
-* Fixed issue with container copy command (#110) @ganeshrn
+  {user}`ganeshrn`
+* Fixed issue with container copy command (#110) {user}`ganeshrn`
 
 ## v0.2.6 (2021-10-29)
 
 ### Bugfixes
 
 * Fixed auto-completion to account for the builtin modules when used
-  with EE (#94) @ganeshrn
+  with EE (#94) {user}`ganeshrn`
 
 ## v0.2.5 (2021-10-23)
 
@@ -58,7 +61,7 @@ https://github.com/ansible/ansible-language-server/tree/main/docs/changelog-frag
 
 * Added a guard for linting only playbook files with the Ansible's
   built-in syntax-check when ansible-lint is unavailable. This is used for
-  providing the diagnostics information (#89) @priyamsahoo
+  providing the diagnostics information (#89) {user}`priyamsahoo`
 
 ## v0.2.4 (2021-10-19)
 
@@ -68,43 +71,45 @@ The most notable changes that happened were:
 
 * Renaming and publishing the package under the `@ansible` scope on
   Npmjs. The new name is `@ansible/ansible-language-server` now
-  (#10) @webknjaz
+  (#10) {user}`webknjaz`
 * Deprecation of the initial `ansible-language-server` npm package that
-  existed in the global namespace prior to the rename @ganeshrn
+  existed in the global namespace prior to the rename {user}`ganeshrn`
 * Adding the auto-completion and diagnostics support for Ansible
-  Execution Environments @ganeshrn
+  Execution Environments {user}`ganeshrn`
 
 ### Changes
 
 * Started falling back to checking playbooks with the Ansible's built-in
   syntax-check when `ansible-lint` is not installed or disabled (#5)
-  @priyamsahoo
+  {user}`priyamsahoo`
 * Set the minimum runtime prerequisites to `npm > 7.11.2` and
-  `node >= 12` (#23) @ssbarnea
+  `node >= 12` (#23) {user}`ssbarnea`
 * Updated the default settings value to use fully qualified collection
-  name (FQCN) during auto-completion (#37) @priyamsahoo
+  name (FQCN) during auto-completion (#37) {user}`priyamsahoo`
 * Added auto-completion support for Ansible Execution Environments
-  (#42 #54 #55) @ganeshrn
+  (#42 #54 #55) {user}`ganeshrn`
 * Added diagnostics support for Ansible Execution Environments (#53)
-  @ganeshrn
+  {user}`ganeshrn`
 * Updated module completion return statement to support sorting as per
-  FQCN (#57) @priyamsahoo
+  FQCN (#57) {user}`priyamsahoo`
 
 ### Bugfixes
 
 * Added a fix to check that the module paths are directories before
-  globbing them during the documentation lookup (#38) @kimbernator
-* Implemented documentation fragment discovery (#40) @tomaciazek
+  globbing them during the documentation lookup (#38)
+  {user}`kimbernator`
+* Implemented documentation fragment discovery (#40) {user}`tomaciazek`
 * Fixed sort `slice()` exception issue in `ansibleConfig` service (#76)
-  @ssbarnea
+  {user}`ssbarnea`
 * Fixed an issue with progress handling when `ansible-lint` falls back
-  to `syntax check` (#88) @yaegassy
+  to `syntax check` (#88) {user}`yaegassy`
 
 ### Misc
 
 * Replaced `decode`/`encodeURI` with a native VS Code mechanism (#8)
-  @tomaciazek
-* Implemented the release CD via `workflow_dispatch` (#65) @webknjaz
+  {user}`tomaciazek`
+* Implemented the release CD via `workflow_dispatch` (#65)
+  {user}`webknjaz`
 
 ## v0.1.0-1 (2021-07-28)
 
@@ -113,4 +118,4 @@ The most notable changes that happened were:
 ## v0.1.0 (2021-07-28)
 
 * Initial ansible language server release. Based on the `vscode-ansible` plugin
-  developed by [Tomasz Maciążek](https://github.com/tomaciazek)
+  developed by {user}`Tomasz Maciążek <tomaciazek>`

--- a/docs/changelog-fragments.d/165.doc.md
+++ b/docs/changelog-fragments.d/165.doc.md
@@ -1,0 +1,2 @@
+Replaced all the credits in the changelog with a dedicated Sphinx role
+-- by {user}`webknjaz`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,18 +5,11 @@
 Ansible
 Bugfixes
 Changelog
-ganeshrn
 globbing
-kimbernator
 linter
 Npmjs
-priyamsahoo
-ssbarnea
 suboptions
-tomaciazek
 unhandled
-webknjaz
-yaegassy
 ```
 
 ```{include} ../CHANGELOG.md


### PR DESCRIPTION
This change is necessary so that we can drop the usernames from
allowlist in the changelog document.