### PR TITLE
Fix GHA check-gate to properly identify failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,19 +430,21 @@ jobs:
           ${{ matrix.node-version }}
 
   check:  # This job does nothing and is only used for the branch protection
+    if: always()
+
     needs:
     - docs
     - lint
     - test
     # - vscode
 
-    runs-on: ubuntu-latest
+    runs-on: Ubuntu-latest
 
     steps:
-      - name: Report success of the test matrix
-        run: >-
-          print("All's good")
-        shell: python
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
 
   publish-npmjs:
     name: Publish ${{ needs.pre-setup.outputs.git-tag }} to Npmjs

--- a/docs/changelog-fragments.d/169.misc.md
+++ b/docs/changelog-fragments.d/169.misc.md
@@ -1,0 +1,2 @@
+Fixed a half-baked change in the GitHub Actions CI/CD workflow job
+that is used in branch protection -- by {user}`webknjaz`


### PR DESCRIPTION
This is achieved by always running the `check` job and inspecting
the needed job results.