### PR TITLE
WIP: Ensure ansible output is parsable

### DIFF
--- a/docs/changelog-fragments.d/173.bugfix.md
+++ b/docs/changelog-fragments.d/173.bugfix.md
@@ -1,0 +1,3 @@
+Disable ANSI escapes when running ansible and ansible-lint to prevent failure
+to parse their output.
+-- by {user}`ssbarnea`

--- a/src/utils/commandRunner.ts
+++ b/src/utils/commandRunner.ts
@@ -31,7 +31,7 @@ export class CommandRunner {
   }> {
     let executablePath: string;
     let command: string;
-    let runEnv: NodeJS.ProcessEnv | undefined;
+    let runEnv: NodeJS.ProcessEnv = process.env;
     const isEEEnabled = this.settings.executionEnvironment.enabled;
     const interpreterPath = isEEEnabled
       ? 'python3'
@@ -59,12 +59,18 @@ export class CommandRunner {
         `${executable} ${args}`,
         mountPaths
       );
-      runEnv = undefined;
     }
+    runEnv['ANSIBLE_FORCE_COLOR'] = '0';
 
-    const currentWorkingDirectory = workingDirectory
-      ? workingDirectory
-      : URI.parse(this.context.workspaceFolder.uri).path;
+    let currentWorkingDirectory = workingDirectory;
+    if (!workingDirectory && this.context?.workspaceFolder.uri) {
+      currentWorkingDirectory = URI.parse(
+        this.context?.workspaceFolder.uri
+      )?.path;
+    }
+    if (!currentWorkingDirectory) {
+      currentWorkingDirectory = process.cwd();
+    }
     const result = await asyncExec(command, {
       encoding: 'utf-8',
       cwd: currentWorkingDirectory,

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -49,12 +49,12 @@ export function withInterpreter(
   args: string,
   interpreterPath: string,
   activationScript: string
-): [string, NodeJS.ProcessEnv | undefined] {
+): [string, NodeJS.ProcessEnv] {
   let command = `${executable} ${args}`; // base case
 
   if (activationScript) {
     command = `bash -c 'source ${activationScript} && ${executable} ${args}'`;
-    return [command, undefined];
+    return [command, process.env];
   }
 
   if (interpreterPath) {
@@ -78,6 +78,6 @@ export function withInterpreter(
 
     return [command, newEnv];
   } else {
-    return [command, undefined];
+    return [command, process.env];
   }
 }

--- a/test/utils/runCommand.test.ts
+++ b/test/utils/runCommand.test.ts
@@ -1,0 +1,30 @@
+import { CommandRunner } from '../../src/utils/commandRunner';
+import { expect } from 'chai';
+import { WorkspaceManager } from '../../src/services/workspaceManager';
+import { createConnection } from 'vscode-languageserver/node';
+import { getDoc } from './helper';
+
+
+describe('commandRunner', () => {
+  it('ansible-force-color', async function () {
+    this.timeout(10000);
+    process.argv.push('--node-ipc');
+    const connection = createConnection();
+    const workspaceManager = new WorkspaceManager(connection);
+    const textDoc = await getDoc('yaml/ancestryBuilder.yml');
+    const context = workspaceManager.getContext(textDoc.uri);
+    const settings = await context.documentSettings.get(textDoc.uri);
+
+    const commandRunner = new CommandRunner(
+      connection,
+      context,
+      settings
+    );
+    const proc = await commandRunner.runCommand('ansible-config', 'dump');
+    // ensure that by default coloring is disabled as its presence can break
+    // parsing of output of multiple tools, including: ansible-playbook, ansible-config and ansible-lint.
+    expect(proc.stdout).contains(
+      'ANSIBLE_FORCE_COLOR(env: ANSIBLE_FORCE_COLOR) = False\nANSIBLE_NOCOLOR(default) = False'
+    );
+  });
+});


### PR DESCRIPTION
In order to avoid erroring parsing output on system where the
user may have configured ansible to always use color, we inject
an override of that option before executing external commands.

This affects both ansible and ansible-lint.

Related: https://github.com/ansible/vscode-ansible/issues/373
