### PR TITLE
chore: avoid coverage report on failed test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "prepack": "npm ci && npm run compile",
     "preversion": "bin/version-bump-allowed",
     "watch": "tsc --watch -p .",
-    "test": "nyc -a mocha --require ts-node/register './test/**/*.ts'",
+    "test": "nyc -s -a mocha --require ts-node/register './test/**/*.ts' && nyc report",
     "check-dependencies": "node ./scripts/check-dependencies.js"
   },
   "all": true


### PR DESCRIPTION
While we want to measure coverage using nyc when running tests, we do not want to display the report unless tests are passing or user calls `npm run coverage` directly.

That is very important because current behaviour makes very hard to debug test failures. Coverage has zero value on test failures.
