### PR TITLE
chore: fix nyc includes

### DIFF
--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -1,0 +1,4 @@
+# Exclude files from elsewhere and avoid random error like
+# https://github.com/istanbuljs/nyc/issues/847
+include:
+  - "src/**/*.ts"


### PR DESCRIPTION
Sorts bug where nyc failed due finding a map file somewhere inside .tox docs. Problem does not reproduce on CI because .tox folder is created only after running some tox jobs.