### PR TITLE
chore: use prettier on markdown files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -2,5 +2,4 @@
 
 Please see the official [Ansible Community Code of Conduct][coc].
 
-[coc]:
-https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
+[coc]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,8 +9,8 @@ In order to contribute, you'll need to:
 
 3. Send it to us as a PR.
 
-4. Iterate on your PR, incorporating the requested improvements
-   and participating in the discussions.
+4. Iterate on your PR, incorporating the requested improvements and
+   participating in the discussions.
 
 Prerequisites:
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,15 +2,14 @@
 
 ## Supported Versions
 
-Ansible Language Server does not backport security fixes only applying
-them to the main branch and making the next patch release in the stream.
+Ansible Language Server does not backport security fixes only applying them to
+the main branch and making the next patch release in the stream.
 
 ## Reporting a Vulnerability
 
-We encourage responsible disclosure practices for security
-vulnerabilities. Please read our [policies for reporting bugs][bug
-reports policy] if you want to report a security issue that might affect
-Ansible.
+We encourage responsible disclosure practices for security vulnerabilities.
+Please read our [policies for reporting bugs][bug reports policy] if you want to
+report a security issue that might affect Ansible.
 
 [bug reports policy]:
-https://docs.ansible.com/ansible/devel/community/reporting_bugs_and_features.html#reporting-a-bug
+  https://docs.ansible.com/ansible/devel/community/reporting_bugs_and_features.html#reporting-a-bug

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
     rev: "v2.5.1"
     hooks:
       - id: prettier
-        types: ["json"]
+        types_or: ["markdown", "json"]
         exclude: >
           (?x)^(
             ansible-language-configuration.json|

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -15,5 +15,9 @@ overrides:
       parser: json5
       quoteProps: preserve
       singleQuote: false
+  - files:
+      - '*.md'
+    options:
+      proseWrap: always
 semi: true
 singleQuote: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 <!-- markdownlint-disable no-duplicate-heading no-multiple-blanks -->
+
 # Change Log
 
-All notable changes to the Ansible VS Code extension will be documented in this file.
+All notable changes to the Ansible VS Code extension will be documented in this
+file.
 
 [//]: # DO-NOT-REMOVE-versioning-promise-START
 
@@ -21,47 +23,44 @@ https://github.com/ansible/ansible-language-server/tree/main/docs/changelog-frag
 
 <!-- towncrier release notes start -->
 
-
 ## v0.4.0 (2021-11-25)
 
 ### Bugfixes
 
-* Prevented throwing an unhandled exception caused by undefined linter
-  arguments settings (#142) {user}`ssbarnea`
-* Implemented opening standalone Ansible files that have no workspace
-  associated (#140) {user}`ganeshrn`
+- Prevented throwing an unhandled exception caused by undefined linter arguments
+  settings (#142) {user}`ssbarnea`
+- Implemented opening standalone Ansible files that have no workspace associated
+  (#140) {user}`ganeshrn`
 
 ## v0.3.0 (2021-11-18)
 
 ### Minor Changes
 
-* Added support for nested module options (suboptions) (#116)
-  {user}`tomaciazek`
-* Adopted use of `creator-ee` execution environment (#132)
-  {user}`ssbarnea`
-* Updated container cleanup logic for execution environment (#111)
+- Added support for nested module options (suboptions) (#116) {user}`tomaciazek`
+- Adopted use of `creator-ee` execution environment (#132) {user}`ssbarnea`
+- Updated container cleanup logic for execution environment (#111)
   {user}`ganeshrn`
 
 ### Bugfixes
 
-* Updated plugin doc cache validate logic for execution environment (#109)
+- Updated plugin doc cache validate logic for execution environment (#109)
   {user}`ganeshrn`
-* Fixed issue with container copy command (#110) {user}`ganeshrn`
+- Fixed issue with container copy command (#110) {user}`ganeshrn`
 
 ## v0.2.6 (2021-10-29)
 
 ### Bugfixes
 
-* Fixed auto-completion to account for the builtin modules when used
-  with EE (#94) {user}`ganeshrn`
+- Fixed auto-completion to account for the builtin modules when used with EE
+  (#94) {user}`ganeshrn`
 
 ## v0.2.5 (2021-10-23)
 
 ### Bugfixes
 
-* Added a guard for linting only playbook files with the Ansible's
-  built-in syntax-check when ansible-lint is unavailable. This is used for
-  providing the diagnostics information (#89) {user}`priyamsahoo`
+- Added a guard for linting only playbook files with the Ansible's built-in
+  syntax-check when ansible-lint is unavailable. This is used for providing the
+  diagnostics information (#89) {user}`priyamsahoo`
 
 ## v0.2.4 (2021-10-19)
 
@@ -69,53 +68,50 @@ https://github.com/ansible/ansible-language-server/tree/main/docs/changelog-frag
 
 The most notable changes that happened were:
 
-* Renaming and publishing the package under the `@ansible` scope on
-  Npmjs. The new name is `@ansible/ansible-language-server` now
-  (#10) {user}`webknjaz`
-* Deprecation of the initial `ansible-language-server` npm package that
-  existed in the global namespace prior to the rename {user}`ganeshrn`
-* Adding the auto-completion and diagnostics support for Ansible
-  Execution Environments {user}`ganeshrn`
+- Renaming and publishing the package under the `@ansible` scope on Npmjs. The
+  new name is `@ansible/ansible-language-server` now (#10) {user}`webknjaz`
+- Deprecation of the initial `ansible-language-server` npm package that existed
+  in the global namespace prior to the rename {user}`ganeshrn`
+- Adding the auto-completion and diagnostics support for Ansible Execution
+  Environments {user}`ganeshrn`
 
 ### Changes
 
-* Started falling back to checking playbooks with the Ansible's built-in
+- Started falling back to checking playbooks with the Ansible's built-in
   syntax-check when `ansible-lint` is not installed or disabled (#5)
   {user}`priyamsahoo`
-* Set the minimum runtime prerequisites to `npm > 7.11.2` and
-  `node >= 12` (#23) {user}`ssbarnea`
-* Updated the default settings value to use fully qualified collection
-  name (FQCN) during auto-completion (#37) {user}`priyamsahoo`
-* Added auto-completion support for Ansible Execution Environments
-  (#42 #54 #55) {user}`ganeshrn`
-* Added diagnostics support for Ansible Execution Environments (#53)
+- Set the minimum runtime prerequisites to `npm > 7.11.2` and `node >= 12` (#23)
+  {user}`ssbarnea`
+- Updated the default settings value to use fully qualified collection name
+  (FQCN) during auto-completion (#37) {user}`priyamsahoo`
+- Added auto-completion support for Ansible Execution Environments (#42 #54 #55)
   {user}`ganeshrn`
-* Updated module completion return statement to support sorting as per
-  FQCN (#57) {user}`priyamsahoo`
+- Added diagnostics support for Ansible Execution Environments (#53)
+  {user}`ganeshrn`
+- Updated module completion return statement to support sorting as per FQCN
+  (#57) {user}`priyamsahoo`
 
 ### Bugfixes
 
-* Added a fix to check that the module paths are directories before
-  globbing them during the documentation lookup (#38)
-  {user}`kimbernator`
-* Implemented documentation fragment discovery (#40) {user}`tomaciazek`
-* Fixed sort `slice()` exception issue in `ansibleConfig` service (#76)
+- Added a fix to check that the module paths are directories before globbing
+  them during the documentation lookup (#38) {user}`kimbernator`
+- Implemented documentation fragment discovery (#40) {user}`tomaciazek`
+- Fixed sort `slice()` exception issue in `ansibleConfig` service (#76)
   {user}`ssbarnea`
-* Fixed an issue with progress handling when `ansible-lint` falls back
-  to `syntax check` (#88) {user}`yaegassy`
+- Fixed an issue with progress handling when `ansible-lint` falls back to
+  `syntax check` (#88) {user}`yaegassy`
 
 ### Misc
 
-* Replaced `decode`/`encodeURI` with a native VS Code mechanism (#8)
+- Replaced `decode`/`encodeURI` with a native VS Code mechanism (#8)
   {user}`tomaciazek`
-* Implemented the release CD via `workflow_dispatch` (#65)
-  {user}`webknjaz`
+- Implemented the release CD via `workflow_dispatch` (#65) {user}`webknjaz`
 
 ## v0.1.0-1 (2021-07-28)
 
-* Updated the npm package to include the `out/` folder
+- Updated the npm package to include the `out/` folder
 
 ## v0.1.0 (2021-07-28)
 
-* Initial ansible language server release. Based on the `vscode-ansible` plugin
+- Initial ansible language server release. Based on the `vscode-ansible` plugin
   developed by {user}`Tomasz Maciążek <tomaciazek>`

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 This language server adds support for Ansible and is currently used by the
 following projects:
 
-* [Ansible extension for vscode/codium](https://github.com/ansible/vscode-ansible)
-* [Ansible extension for coc.nvim](https://github.com/yaegassy/coc-ansible)
+- [Ansible extension for vscode/codium](https://github.com/ansible/vscode-ansible)
+- [Ansible extension for coc.nvim](https://github.com/yaegassy/coc-ansible)
 
 ## Features
 
@@ -38,15 +38,15 @@ is provided instantaneously.
 
 On opening and saving a document, `ansible-lint` is executed in the background
 and any findings are presented as errors. You might find it useful that
-rules/tags added to `warn_list`
-(see [Ansible Lint Documentation](https://ansible-lint.readthedocs.io/en/latest/configuring.html))
+rules/tags added to `warn_list` (see
+[Ansible Lint Documentation](https://ansible-lint.readthedocs.io/en/latest/configuring.html))
 are shown as warnings instead.
 
 > If you also install `yamllint`, `ansible-lint` will detect it and incorporate
 > into the linting process. Any findings reported by `yamllint` will be exposed
 > in VSCode as errors/warnings.
 
-***Note***
+**_Note_**
 
 If `ansible-lint` is not installed/found or running `ansible-lint` results in
 error it will fallback to `ansible --syntax-check` for validation.
@@ -59,23 +59,23 @@ The extension tries to detect whether the cursor is on a play, block or task
 etc. and provides suggestions accordingly. There are also a few other rules that
 improve user experience:
 
-* the `name` property is always suggested first
-* on module options, the required properties are shown first, and aliases are
+- the `name` property is always suggested first
+- on module options, the required properties are shown first, and aliases are
   shown last, otherwise ordering from the documentation is preserved
-* FQCNs (fully qualified collection names) are inserted only when necessary;
+- FQCNs (fully qualified collection names) are inserted only when necessary;
   collections configured with the [`collections` keyword] are honored. This
   behavior can be disabled in extension settings.
 
 [`collections` keyword]:
-https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#simplifying-module-names-with-the-collections-keyword
+  https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#simplifying-module-names-with-the-collections-keyword
 
 #### Auto-closing Jinja expressions
 
 ![Easier Jinja expression typing](https://github.com/ansible/ansible-language-server/raw/main/images/jinja-expression.gif)
 
-When writing a Jinja expression, you only need to type `"{{<space>`, and it
-will be mirrored behind the cursor (including the space). You can also select
-the whole expression and press `space` to put spaces on both sides of the
+When writing a Jinja expression, you only need to type `"{{<space>`, and it will
+be mirrored behind the cursor (including the space). You can also select the
+whole expression and press `space` to put spaces on both sides of the
 expression.
 
 ### Documentation reference
@@ -90,47 +90,48 @@ the documentation straight from the Python implementation of the modules.
 
 ![Go to code on Ctrl+click](https://github.com/ansible/ansible-language-server/raw/main/images/go-to-definition.gif)
 
-You may also open the implementation of any module using the standard *Go to
-Definition* operation, for instance, by clicking on the module name while
+You may also open the implementation of any module using the standard _Go to
+Definition_ operation, for instance, by clicking on the module name while
 holding `ctrl`/`cmd`.
 
 ## Language Server Settings
 
 The following settings are supported.
 
-* `ansible.ansible.path`: Path to the `ansible` executable. Default is `ansible`,
-  which means $PATH is searched for the executable.
-* `ansible.ansible.useFullyQualifiedCollectionNames`: Toggles use of
-  fully qualified collection names (FQCN) when inserting a module name.
-  Disabling it will only use FQCNs when necessary, that is when the collection
-  is not configured for the task. Default is `true`.
-* `ansible.ansibleLint.arguments`: Optional command line arguments to be
-  appended to `ansible-lint` invocation. See `ansible-lint` documentation. Default
-  is empty string.
-* `ansible.ansibleLint.enabled`: Enables/disables use of `ansible-lint`. default
+- `ansible.ansible.path`: Path to the `ansible` executable. Default is
+  `ansible`, which means $PATH is searched for the executable.
+- `ansible.ansible.useFullyQualifiedCollectionNames`: Toggles use of fully
+  qualified collection names (FQCN) when inserting a module name. Disabling it
+  will only use FQCNs when necessary, that is when the collection is not
+  configured for the task. Default is `true`.
+- `ansible.ansibleLint.arguments`: Optional command line arguments to be
+  appended to `ansible-lint` invocation. See `ansible-lint` documentation.
+  Default is empty string.
+- `ansible.ansibleLint.enabled`: Enables/disables use of `ansible-lint`. default
   is `true`.
-* `ansible.ansibleLint.path`: Path to the `ansible-lint` executable. Default is
+- `ansible.ansibleLint.path`: Path to the `ansible-lint` executable. Default is
   `ansible-lint`, which means $PATH is searched for the executable.
-* `ansible.ansibleNavigator.path`: Path to the `ansible-navigator` executable.
-* `ansible.ansiblePlaybook.path`: Path to the `ansible-playbook` executable.
-* `ansible.executionEnvironment.containerEngine`: The container engine to be used
-  while running with execution environment. Valid values are `auto`, `podman` and
-  `docker`. For `auto` it will look for `podman` then `docker`. Default is `auto`.
-* `ansible.executionEnvironment.enabled`: Enable or disable the use of an
-   execution environment. Default is `false`.
-* `ansible.executionEnvironment.image`: Specify the name of the execution
+- `ansible.ansibleNavigator.path`: Path to the `ansible-navigator` executable.
+- `ansible.ansiblePlaybook.path`: Path to the `ansible-playbook` executable.
+- `ansible.executionEnvironment.containerEngine`: The container engine to be
+  used while running with execution environment. Valid values are `auto`,
+  `podman` and `docker`. For `auto` it will look for `podman` then `docker`.
+  Default is `auto`.
+- `ansible.executionEnvironment.enabled`: Enable or disable the use of an
+  execution environment. Default is `false`.
+- `ansible.executionEnvironment.image`: Specify the name of the execution
   environment image. Default is `quay.io/ansible/creator-ee:latest`.
-* `ansible.executionEnvironment.pullPolicy`: Specify the image pull policy.
+- `ansible.executionEnvironment.pullPolicy`: Specify the image pull policy.
   Valid values are `always`, `missing`, `never` and `tag`. Setting `always` will
-  always pull the image when extension is activated or reloaded. Default is `missing`.
-  Setting `missing` will pull if not locally available. Setting `never` will
-  never pull the image and setting tag will always pull if the image tag is
-  'latest', otherwise pull if not locally available.
-* `ansible.python.interpreterPath`: Path to the `python`/`python3` executable.
+  always pull the image when extension is activated or reloaded. Default is
+  `missing`. Setting `missing` will pull if not locally available. Setting
+  `never` will never pull the image and setting tag will always pull if the
+  image tag is 'latest', otherwise pull if not locally available.
+- `ansible.python.interpreterPath`: Path to the `python`/`python3` executable.
   This setting may be used to make the extension work with `ansible` and
   `ansible-lint` installations in a Python virtual environment. Default is empty
   string.
-* `ansible.python.activationScript`: Path to a custom `activate` script, which
+- `ansible.python.activationScript`: Path to a custom `activate` script, which
   will be used instead of the setting above to run in a Python virtual
   environment. Default is empty string.
 
@@ -140,29 +141,30 @@ For details on setting up development environment and debugging refer to the
 [development document].
 
 [development document]:
-https://github.com/ansible/ansible-language-server/blob/main/docs/development.md
+  https://github.com/ansible/ansible-language-server/blob/main/docs/development.md
 
 ## Requirements
 
-* [Ansible 2.9+](https://docs.ansible.com/ansible/latest/index.html)
-* [Ansible Lint](https://ansible-lint.readthedocs.io/en/latest/) (required,
+- [Ansible 2.9+](https://docs.ansible.com/ansible/latest/index.html)
+- [Ansible Lint](https://ansible-lint.readthedocs.io/en/latest/) (required,
   unless you disable linter support)
-* [yamllint](https://yamllint.readthedocs.io/en/stable/) (optional)
+- [yamllint](https://yamllint.readthedocs.io/en/stable/) (optional)
 
 For Windows users, this extension works perfectly well with extensions such as
 `Remote - WSL` and `Remote - Containers`.
 
 > If you have any other extension providing language support for Ansible, you
-  might need to uninstall it first.
+> might need to uninstall it first.
 
 ## Known limitations
 
-* The shorthand syntax for module options (key=value pairs) is not supported.
-* Only Jinja *expressions* inside Ansible YAML files are supported. In order to
+- The shorthand syntax for module options (key=value pairs) is not supported.
+- Only Jinja _expressions_ inside Ansible YAML files are supported. In order to
   have syntax highlighting of Jinja template files, you'll need to install other
   extension.
-* Jinja *blocks* (inside Ansible YAML files) are not supported yet.
+- Jinja _blocks_ (inside Ansible YAML files) are not supported yet.
 
 ## Credit
 
-Based on the good work done by [Tomasz Maciążek](https://github.com/tomaciazek/vscode-ansible)
+Based on the good work done by
+[Tomasz Maciążek](https://github.com/tomaciazek/vscode-ansible)

--- a/docs/changelog-fragments.d/161.misc.md
+++ b/docs/changelog-fragments.d/161.misc.md
@@ -1,4 +1,4 @@
-Added [Sphinx][sphinx] documentation generator and set up the CI
-infrastructure for it -- by {user}`webknjaz`
+Added [Sphinx][sphinx] documentation generator and set up the CI infrastructure
+for it -- by {user}`webknjaz`
 
 [sphinx]: https://github.com/twisted/towncrier

--- a/docs/changelog-fragments.d/164.doc.md
+++ b/docs/changelog-fragments.d/164.doc.md
@@ -1,5 +1,5 @@
-Dropped the brackets from the changelog titles for the release sections.
-We now don't strictly follow the release notes format suggested by
-[Keep a Changelog][keepachangelog] -- by {user}`webknjaz`
+Dropped the brackets from the changelog titles for the release sections. We now
+don't strictly follow the release notes format suggested by [Keep a
+Changelog][keepachangelog] -- by {user}`webknjaz`
 
 [keepachangelog]: https://keepachangelog.com/en/1.1.0/

--- a/docs/changelog-fragments.d/165.doc.md
+++ b/docs/changelog-fragments.d/165.doc.md
@@ -1,2 +1,2 @@
-Replaced all the credits in the changelog with a dedicated Sphinx role
--- by {user}`webknjaz`
+Replaced all the credits in the changelog with a dedicated Sphinx role -- by
+{user}`webknjaz`

--- a/docs/changelog-fragments.d/169.misc.md
+++ b/docs/changelog-fragments.d/169.misc.md
@@ -1,2 +1,2 @@
-Fixed a half-baked change in the GitHub Actions CI/CD workflow job
-that is used in branch protection -- by {user}`webknjaz`
+Fixed a half-baked change in the GitHub Actions CI/CD workflow job that is used
+in branch protection -- by {user}`webknjaz`

--- a/docs/changelog-fragments.d/README.md
+++ b/docs/changelog-fragments.d/README.md
@@ -4,48 +4,41 @@
 
 ## Adding change notes with your PRs
 
-It is very important to maintain a log for news of how
-updating to the new version of the software will affect
-end-users. This is why we enforce collection of the change
-fragment files in pull requests as per
-[Towncrier philosophy][towncrier-philosophy].
+It is very important to maintain a log for news of how updating to the new
+version of the software will affect end-users. This is why we enforce collection
+of the change fragment files in pull requests as per [Towncrier
+philosophy][towncrier-philosophy].
 
-The idea is that when somebody makes a change, they must record
-the bits that would affect end-users only including information
-that would be useful to them. Then, when the maintainers publish
-a new release, they'll automatically use these records to compose
-a change log for the respective version. It is important to
-understand that including unnecessary low-level implementation
-related details generates noise that is not particularly useful
-to the end-users most of the time. And so such details should be
-recorded in the Git history rather than a changelog.
+The idea is that when somebody makes a change, they must record the bits that
+would affect end-users only including information that would be useful to them.
+Then, when the maintainers publish a new release, they'll automatically use
+these records to compose a change log for the respective version. It is
+important to understand that including unnecessary low-level implementation
+related details generates noise that is not particularly useful to the end-users
+most of the time. And so such details should be recorded in the Git history
+rather than a changelog.
 
 ## Alright! So how do I add a news fragment?
 
 To submit a change note about your PR, add a text file into the
-`docs/changelog-fragments.d/` folder. It should contain an
-explanation of what applying this PR will change in the way
-end-users interact with the project. One sentence is usually
-enough but feel free to add as many details as you feel necessary
-for the users to understand what it means.
+`docs/changelog-fragments.d/` folder. It should contain an explanation of what
+applying this PR will change in the way end-users interact with the project. One
+sentence is usually enough but feel free to add as many details as you feel
+necessary for the users to understand what it means.
 
-**Use the past tense** for the text in your fragment because,
-combined with others, it will be a part of the "news digest"
-telling the readers **what changed** in a specific version of
-the library *since the previous version*. You should also use
-[MyST Markdown][myst-md] syntax for highlighting code (inline or block),
-linking parts of the docs or external sites.
-At the end, sign your change note by adding ```-- by
-{user}`github-username``` (replace `github-username` with
-your own!).
+**Use the past tense** for the text in your fragment because, combined with
+others, it will be a part of the "news digest" telling the readers **what
+changed** in a specific version of the library _since the previous version_. You
+should also use [MyST Markdown][myst-md] syntax for highlighting code (inline or
+block), linking parts of the docs or external sites. At the end, sign your
+change note by adding `` -- by {user}`github-username `` (replace
+`github-username` with your own!).
 
-Finally, name your file following the convention that Towncrier
-understands: it should start with the number of an issue or a
-PR followed by a dot, then add a patch type, like `feature`,
-`bugfix`, `doc`, `misc` etc., and add `.md` as a suffix. If you
-need to add more than one fragment, you may add an optional
-sequence number (delimited with another period) between the type
-and the suffix.
+Finally, name your file following the convention that Towncrier understands: it
+should start with the number of an issue or a PR followed by a dot, then add a
+patch type, like `feature`, `bugfix`, `doc`, `misc` etc., and add `.md` as a
+suffix. If you need to add more than one fragment, you may add an optional
+sequence number (delimited with another period) between the type and the suffix.
 
 ## Examples for changelog entries adding to your Pull Requests
 
@@ -58,15 +51,14 @@ Added a `{user}` role to Sphinx config -- by {user}`webknjaz`
 File `docs/changelog-fragments.d/116.feature.md`:
 
 ```md
-Added support for nested module options (suboptions)
--- by {user}`tomaciazek`
+Added support for nested module options (suboptions) -- by {user}`tomaciazek`
 ```
 
 File `docs/changelog-fragments.d/140.bugfix.md`:
 
 ```md
-Implemented opening standalone Ansible files that have no workspace
-associated -- by {user}`ganeshrn`
+Implemented opening standalone Ansible files that have no workspace associated
+-- by {user}`ganeshrn`
 ```
 
 ```{tip}
@@ -74,7 +66,6 @@ See `pyproject.toml` for all available categories
 (`tool.towncrier.type`).
 ```
 
-[myst-md]:
-https://myst-parser.rtfd.io/en/latest/syntax/syntax.html
+[myst-md]: https://myst-parser.rtfd.io/en/latest/syntax/syntax.html
 [towncrier-philosophy]:
-https://towncrier.rtfd.io/en/actual-freaking-docs/#philosophy
+  https://towncrier.rtfd.io/en/actual-freaking-docs/#philosophy

--- a/docs/contributing/code_of_conduct.md
+++ b/docs/contributing/code_of_conduct.md
@@ -1,3 +1,5 @@
 <!-- markdownlint-disable first-line-heading -->
+
 ```{include} ../../.github/CODE_OF_CONDUCT.md
+
 ```

--- a/docs/contributing/guidelines.md
+++ b/docs/contributing/guidelines.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable first-line-heading -->
+
 ```{spelling}
 de
 facto
@@ -9,12 +10,13 @@ Towncrier
 ```
 
 ```{include} ../../.github/CONTRIBUTING.md
+
 ```
 
 # Contributing docs
 
-We use [Sphinx][sphinx] to generate our docs website. You can trigger
-the process locally by executing:
+We use [Sphinx][sphinx] to generate our docs website. You can trigger the
+process locally by executing:
 
 ```shell-session
 $ tox -e build-docs
@@ -38,21 +40,20 @@ _______________________________________________________ summary ________________
   congratulations :)
 ```
 
-It is also integrated with [Read The Docs][rtd] that builds and
-publishes each commit to the main branch and generates live
-docs previews for each pull request.
+It is also integrated with [Read The Docs][rtd] that builds and publishes each
+commit to the main branch and generates live docs previews for each pull
+request.
 
-The sources of the [Sphinx][sphinx] documents use reStructuredText as a
-de-facto standard. But in order to make contributing docs more
-beginner-friendly, we have integrated [MyST parser][myst] allowing us
-to also accept new documents written in an extended version of
-Markdown that supports using Sphinx directives and roles.
-{ref}`Read the docs <myst:intro/writing>` to learn more on how
-to use it.
+The sources of the [Sphinx][sphinx] documents use reStructuredText as a de-facto
+standard. But in order to make contributing docs more beginner-friendly, we have
+integrated [MyST parser][myst] allowing us to also accept new documents written
+in an extended version of Markdown that supports using Sphinx directives and
+roles. {ref}`Read the docs <myst:intro/writing>` to learn more on how to use it.
 
 [myst]: https://pypi.org/project/myst-parser/
 [rtd]: https://readthedocs.org
 [sphinx]: https://www.sphinx-doc.org
 
 ```{include} ../changelog-fragments.d/README.md
+
 ```

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -1,7 +1,9 @@
 <!-- markdownlint-disable first-line-heading -->
+
 ```{spelling}
 backport
 ```
 
 ```{include} ../../.github/SECURITY.md
+
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,8 +4,8 @@
 
 A demo of the setup can be found [on youtube](https://youtu.be/LsvWsX7Mbo8).
 
-It is recommended to work on the forked copy of this repository from your
-github account to raise pull requests.
+It is recommended to work on the forked copy of this repository from your github
+account to raise pull requests.
 
 ```bash
 git clone git@github.com:<your-github-id>/ansible-language-server.git
@@ -17,17 +17,17 @@ git checkout -b <name_of_branch> upstream/main
 
 ## Running & debugging the language-server with VS Code
 
-* Install dependent packages within ansible-language-server root directory
+- Install dependent packages within ansible-language-server root directory
 
 ```console
 ansible-language-server$ npm install .
 ```
 
-This will install the dependent modules under `node_modules` folder within
-the current directory.
+This will install the dependent modules under `node_modules` folder within the
+current directory.
 
-* Clone the repository containing the VS Code extension code into the
-  `vscode-ansible` directory *next to* the root directory of this repository.
+- Clone the repository containing the VS Code extension code into the
+  `vscode-ansible` directory _next to_ the root directory of this repository.
 
 ```bash
 cd ..
@@ -35,31 +35,32 @@ git clone git@github.com:ansible/vscode-ansible.git
 cd vscode-ansible
 ```
 
-* Open a new VS Code window and add folder to workspace
+- Open a new VS Code window and add folder to workspace
   `File -> Add folder to workspace` and add `vscode-ansible` and
   `ansible-language-server` folders to the workspace
 
-* Once the language server and `vscode-ansible/` directory is prepared,
-  compile both client and server using command
+- Once the language server and `vscode-ansible/` directory is prepared, compile
+  both client and server using command
 
 ```bash
 npm run compile:withserver
 ```
 
-* In the Run and debug window select **Client + Server (source)** configuration
-  and start debugging `Run -> Start Debugging`. This will open up a new VS Code window
-  which is the `Extension development Host` window.
+- In the Run and debug window select **Client + Server (source)** configuration
+  and start debugging `Run -> Start Debugging`. This will open up a new VS Code
+  window which is the `Extension development Host` window.
 
-* In the `Extension development Host` window add a new folder that has ansible files.
+- In the `Extension development Host` window add a new folder that has ansible
+  files.
 
-* You can set the ansible-language-server settings by adding
+- You can set the ansible-language-server settings by adding
   `.vscode/settings.json` file under the root folder. Example settings:
 
 ```json
 {
-    "ansible.python.interpreterPath": "<change to python3 executable path>",
-    "ansible.ansible.path": "<change to ansible executable path>",
-    "ansibleServer.trace.server": "verbose"
+  "ansible.python.interpreterPath": "<change to python3 executable path>",
+  "ansible.ansible.path": "<change to ansible executable path>",
+  "ansibleServer.trace.server": "verbose"
 }
 ```
 
@@ -73,8 +74,9 @@ modes.
 ### Building server locally
 
 1. Install prerequisites:
-   * latest [Visual Studio Code](https://code.visualstudio.com/)
-   * [Node.js](https://nodejs.org/) v12.0.0 or higher
+
+   - latest [Visual Studio Code](https://code.visualstudio.com/)
+   - [Node.js](https://nodejs.org/) v12.0.0 or higher
 
 2. Fork and clone this repository
 


### PR DESCRIPTION
This should ensure that we no longer get surprise changes when we edit tracked `.md` files in vscode as it applies all prettier rules, while still passing our markdown linting.

Please note that markdown files touched by this change are result of running pre-commit, no other manual changes were made.

Based on https://github.com/ansible/vscode-ansible/pull/386