### PR TITLE
chore: prepare md for prettier

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@ In order to contribute, you'll need to:
 1. Fork the repository.
 
 2. Create a branch, push your changes there. Don't forget to
-   {ref}`include news files for the changelog <_ansible_language_server_adding_changelog_fragments>`.
+   {ref}`include news files for the changelog <ansible_language_server_adding_changelog_fragments>`.
 
 3. Send it to us as a PR.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 All notable changes to the Ansible VS Code extension will be documented in this file.
 
-[//]: # (DO-NOT-REMOVE-versioning-promise-START)
+[//]: # DO-NOT-REMOVE-versioning-promise-START
 
 ```{note}
 The change notes follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Language Server
 
-[//]: # (DO-NOT-REMOVE-README-TITLE)
+[//]: # DO-NOT-REMOVE-README-TITLE
 
 This language server adds support for Ansible and is currently used by the
 following projects:

--- a/docs/changelog-fragments.d/README.md
+++ b/docs/changelog-fragments.d/README.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable first-line-heading -->
 
-(_ansible_language_server_adding_changelog_fragments)=
+(ansible_language_server_adding_changelog_fragments)=
 
 ## Adding change notes with your PRs
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,17 +14,22 @@ unhandled
 
 ```{include} ../CHANGELOG.md
 :end-before: <!-- towncrier release notes start -->
-:start-after: (DO-NOT-REMOVE-versioning-promise-START)
+:start-after: DO-NOT-REMOVE-versioning-promise-START
 
 ```
 
-<!-- markdownlint-disable-next-line no-space-in-emphasis -->
+<!-- markdownlint-disable no-space-in-emphasis -->
+
 ## {{ release_l }}, as of {sub-ref}`today` _{subscript}`/UNRELEASED DRAFT/`_
 
+<!-- markdownlint-restore -->
+
 ```{important} This version is not yet released and is under active development
+
 ```
 
 ```{towncrier-draft-entries}
+
 ```
 
 ```{include} ../CHANGELOG.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,16 @@
 <!-- markdownlint-disable first-line-heading -->
+
 ```{spelling}
 
 linter
 ```
 
-(_ansible_language_server_index)=
+(\_ansible_language_server_index)=
 
 # {{ project }} Documentation
 
 ```{include} ../README.md
-:start-after: (DO-NOT-REMOVE-README-TITLE)
+:start-after: DO-NOT-REMOVE-README-TITLE
 ```
 
 ```{toctree}


### PR DESCRIPTION
Ensures that our markdown files do not contain syntax that would be modified (broke) by prettier.

That is preparatory change containing some manual fixes that were needed as part of #177 but we took them separately in order to ease the review.
