### PR TITLE
Ensure runEnv is always a dictionary

### DIFF
--- a/src/utils/commandRunner.ts
+++ b/src/utils/commandRunner.ts
@@ -31,7 +31,7 @@ export class CommandRunner {
   }> {
     let executablePath: string;
     let command: string;
-    let runEnv: NodeJS.ProcessEnv | undefined;
+    let runEnv: NodeJS.ProcessEnv = {};
     const isEEEnabled = this.settings.executionEnvironment.enabled;
     const interpreterPath = isEEEnabled
       ? 'python3'
@@ -59,7 +59,6 @@ export class CommandRunner {
         `${executable} ${args}`,
         mountPaths
       );
-      runEnv = undefined;
     }
 
     const currentWorkingDirectory = workingDirectory

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -49,12 +49,12 @@ export function withInterpreter(
   args: string,
   interpreterPath: string,
   activationScript: string
-): [string, NodeJS.ProcessEnv | undefined] {
+): [string, NodeJS.ProcessEnv] {
   let command = `${executable} ${args}`; // base case
 
   if (activationScript) {
     command = `bash -c 'source ${activationScript} && ${executable} ${args}'`;
-    return [command, undefined];
+    return [command, {}];
   }
 
   if (interpreterPath) {
@@ -78,6 +78,6 @@ export function withInterpreter(
 
     return [command, newEnv];
   } else {
-    return [command, undefined];
+    return [command, process.env];
   }
 }


### PR DESCRIPTION
Replace use of undefined with an empty dictionary as this will
ease implementing changes from #173 and make the code more robust.
