### PR TITLE
Fix nyc configuration

### DIFF
--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -1,4 +1,13 @@
+# https://github.com/istanbuljs/nyc
 # Exclude files from elsewhere and avoid random error like
 # https://github.com/istanbuljs/nyc/issues/847
 include:
   - "src/**/*.ts"
+recursive: true
+require:
+  - ts-node/register
+temp-dir: out/.nyc_output
+report-dir: out/coverage
+skip-full: true
+# increase threshold once possible:
+lines: 24

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "prepack": "npm ci && npm run compile",
     "preversion": "bin/version-bump-allowed",
     "watch": "tsc --watch -p .",
-    "test": "nyc -s -a mocha && nyc report",
+    "test": "nyc -s -a mocha && nyc report --check-coverage",
     "check-dependencies": "node ./scripts/check-dependencies.js"
   },
   "all": true


### PR DESCRIPTION
Previously nyc was not reporting lack of coverage for lots of files due to incorrect setup and the reported coverage was far bigger than real.

This also ensures that we fail the build if coverage goes below current level.