### PR TITLE
Add defaults to settings section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,37 +98,41 @@ holding `ctrl`/`cmd`.
 
 The following settings are supported.
 
-* `ansible.ansible.path`: Path to the `ansible` executable.
+* `ansible.ansible.path`: Path to the `ansible` executable. Default is `ansible`,
+  which means $PATH is searched for the executable.
 * `ansible.ansible.useFullyQualifiedCollectionNames`: Toggles use of
   fully qualified collection names (FQCN) when inserting a module name.
   Disabling it will only use FQCNs when necessary, that is when the collection
-  is not configured for the task.
+  is not configured for the task. Default is `true`.
 * `ansible.ansibleLint.arguments`: Optional command line arguments to be
-  appended to `ansible-lint` invocation. See `ansible-lint` documentation.
-* `ansible.ansibleLint.enabled`: Enables/disables use of `ansible-lint`.
-* `ansible.ansibleLint.path`: Path to the `ansible-lint` executable.
+  appended to `ansible-lint` invocation. See `ansible-lint` documentation. Default
+  is empty string.
+* `ansible.ansibleLint.enabled`: Enables/disables use of `ansible-lint`. default
+  is `true`.
+* `ansible.ansibleLint.path`: Path to the `ansible-lint` executable. Default is
+  `ansible-lint`, which means $PATH is searched for the executable.
 * `ansible.ansibleNavigator.path`: Path to the `ansible-navigator` executable.
 * `ansible.ansiblePlaybook.path`: Path to the `ansible-playbook` executable.
 * `ansible.executionEnvironment.containerEngine`: The container engine to be used
   while running with execution environment. Valid values are `auto`, `podman` and
-  `docker`. For `auto` it will look for `podman` then `docker`.
+  `docker`. For `auto` it will look for `podman` then `docker`. Default is `auto`.
 * `ansible.executionEnvironment.enabled`: Enable or disable the use of an
-   execution environment.
+   execution environment. Default is `false`.
 * `ansible.executionEnvironment.image`: Specify the name of the execution
-  environment image.
+  environment image. Default is `quay.io/ansible/creator-ee:latest`.
 * `ansible.executionEnvironment.pullPolicy`: Specify the image pull policy.
-  Valid values are `always`,
-  `missing`, `never` and `tag`. Setting `always` will always pull the image
-  when extension is activated or reloaded.
+  Valid values are `always`, `missing`, `never` and `tag`. Setting `always` will
+  always pull the image when extension is activated or reloaded. Default is `missing`.  
   Setting `missing` will pull if not locally available. Setting `never` will
   never pull the image and setting tag will always pull if the image tag is
   'latest', otherwise pull if not locally available.
 * `ansible.python.interpreterPath`: Path to the `python`/`python3` executable.
   This setting may be used to make the extension work with `ansible` and
-  `ansible-lint` installations in a Python virtual environment.
+  `ansible-lint` installations in a Python virtual environment. Default is empty
+  string.
 * `ansible.python.activationScript`: Path to a custom `activate` script, which
   will be used instead of the setting above to run in a Python virtual
-  environment.
+  environment. Default is empty string.
 
 ## Developer support
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The following settings are supported.
   environment image. Default is `quay.io/ansible/creator-ee:latest`.
 * `ansible.executionEnvironment.pullPolicy`: Specify the image pull policy.
   Valid values are `always`, `missing`, `never` and `tag`. Setting `always` will
-  always pull the image when extension is activated or reloaded. Default is `missing`.  
+  always pull the image when extension is activated or reloaded. Default is `missing`.
   Setting `missing` will pull if not locally available. Setting `never` will
   never pull the image and setting tag will always pull if the image tag is
   'latest', otherwise pull if not locally available.


### PR DESCRIPTION
Having the defaults in README.md might help people not familiar with code. One can see at first glance what is set by default and if changes are actually needed.

Having never used Typescript so far, I couldn't find the defaults for `ansible.ansibleNavigator.path` and `ansible.ansiblePlaybook.path`, but I guess it's the executable's name too as for ansible and ansible-lint. If so, I'm happy to add this, sqash and rebase if needed.