### PR TITLE
Make Windows tests unblock the CI/PR gating mechanism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,7 @@ jobs:
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
         npm ci
     - name: Log ansible-lint version
+      if: runner.os != 'Windows'
       run: ansible-lint --version
     - name: Run testing against the Git checkout
       run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,10 +423,10 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
         npm ci
+    - name: Log ansible-lint version
+      run: ansible-lint --version
     - name: Run testing against the Git checkout
-      run: |
-        ansible-lint --version
-        npm test
+      run: npm test
 
     - name: Produce coverage report
       run: npm run coverage


### PR DESCRIPTION
This patch makes the prerequisite check for `ansible-lint` version skipped under Windows. It's necessary because the latest version started failing loudly in that environment.

For the future, we'll have to reevaluate how we set up testing for the Windows users but right now this band-aid is enough to unblock folks immediately.