### PR TITLE
Make runCommand strip ANSI codes

### DIFF
--- a/docs/changelog-fragments.d/194.bugfix.md
+++ b/docs/changelog-fragments.d/194.bugfix.md
@@ -1,0 +1,3 @@
+Ensure ANSI escapes are removed from stdout/stderr
+[#373][https://github.com/ansible/vscode-ansible/issues/373]
+-- by {user}`ssbarnea`

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,2 +1,4 @@
 Ansible
 ansible
+stderr
+stdout

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "@electerm/strip-ansi": "^1.0.0",
         "@flatten-js/interval-tree": "^1.0.14",
         "globby": "^11.0.4",
         "ini": "^1.3.8",
@@ -515,6 +516,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@electerm/strip-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@electerm/strip-ansi/-/strip-ansi-1.0.0.tgz",
+      "integrity": "sha512-taZnYu/i473T8qx5kzJSqMWKrOSVh32XZpWGOFgN6zvBMPqLjUY+/9z2qncpo9/otzaN29F3e4Ulbv+PevZccA=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
@@ -4322,6 +4328,11 @@
         "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@electerm/strip-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@electerm/strip-ansi/-/strip-ansi-1.0.0.tgz",
+      "integrity": "sha512-taZnYu/i473T8qx5kzJSqMWKrOSVh32XZpWGOFgN6zvBMPqLjUY+/9z2qncpo9/otzaN29F3e4Ulbv+PevZccA=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "LSP"
   ],
   "dependencies": {
+    "@electerm/strip-ansi": "^1.0.0",
     "@flatten-js/interval-tree": "^1.0.14",
     "globby": "^11.0.4",
     "ini": "^1.3.8",

--- a/src/utils/commandRunner.ts
+++ b/src/utils/commandRunner.ts
@@ -4,6 +4,7 @@ import { withInterpreter, asyncExec } from './misc';
 import { getAnsibleCommandExecPath } from './execPath';
 import { WorkspaceFolderContext } from '../services/workspaceManager';
 import { ExtensionSettings } from '../interfaces/extensionSettings';
+import stripAnsi from '@electerm/strip-ansi';
 
 export class CommandRunner {
   private connection: Connection;
@@ -24,7 +25,8 @@ export class CommandRunner {
     executable: string,
     args: string,
     workingDirectory?: string,
-    mountPaths?: Set<string>
+    mountPaths?: Set<string>,
+    keepAnsi = false
   ): Promise<{
     stdout: string;
     stderr: string;
@@ -71,6 +73,10 @@ export class CommandRunner {
       env: runEnv,
     });
 
+    if (!keepAnsi) {
+      result.stdout = stripAnsi(result.stdout);
+      result.stderr = stripAnsi(result.stderr);
+    }
     return result;
   }
 

--- a/test/utils/runCommand.test.ts
+++ b/test/utils/runCommand.test.ts
@@ -4,19 +4,47 @@ import { WorkspaceManager } from '../../src/services/workspaceManager';
 import { createConnection } from 'vscode-languageserver/node';
 import { getDoc, isWindows } from './helper';
 
-
 describe('commandRunner', () => {
-
   const tests = [
-    { args: ['ansible-config', 'dump'], rc: 0, stdout: 'ANSIBLE_FORCE_COLOR', stderr: '' },
-    { args: ['ansible', '--version'], rc: 0, stdout: 'configured module search path', stderr: '' },
-    { args: ['ansible-lint', '--version'], rc: 0, stdout: 'using ansible', stderr: '' },
-    { args: ['ansible-playbook', 'missing-file'], rc: 1, stdout: '', stderr: 'ERROR! the playbook: missing-file could not be found' },
-  ]
+    {
+      args: ['echo', 'Is this \u001b[31mRED\u001b[39m?'],
+      rc: 0,
+      stdout: 'Is this RED?\n',
+      stderr: '',
+      keepAnsi: false,
+    },
+    {
+      args: ['ansible-config', 'dump'],
+      rc: 0,
+      stdout: 'ANSIBLE_FORCE_COLOR',
+      stderr: '',
+      keepAnsi: true,
+    },
+    {
+      args: ['ansible', '--version'],
+      rc: 0,
+      stdout: 'configured module search path',
+      stderr: '',
+      keepAnsi: false,
+    },
+    {
+      args: ['ansible-lint', '--version'],
+      rc: 0,
+      stdout: 'using ansible',
+      stderr: '',
+      keepAnsi: false,
+    },
+    {
+      args: ['ansible-playbook', 'missing-file'],
+      rc: 1,
+      stdout: '',
+      stderr: 'ERROR! the playbook: missing-file could not be found',
+      keepAnsi: false,
+    },
+  ];
 
-  tests.forEach(({ args, rc, stdout, stderr }) => {
+  tests.forEach(({ args, rc, stdout, stderr, keepAnsi }) => {
     it(`call ${args.join(' ')}`, async function () {
-
       this.timeout(10000);
       process.argv.push('--node-ipc');
       const connection = createConnection();
@@ -25,24 +53,25 @@ describe('commandRunner', () => {
       const context = workspaceManager.getContext(textDoc.uri);
       const settings = await context.documentSettings.get(textDoc.uri);
 
-      const commandRunner = new CommandRunner(
-        connection,
-        context,
-        settings
-      );
+      const commandRunner = new CommandRunner(connection, context, settings);
       try {
-        const proc = await commandRunner.runCommand(args[0], args.slice(1).join(' '));
+        const proc = await commandRunner.runCommand(
+          args[0],
+          args.slice(1).join(' '),
+          undefined,
+          undefined,
+          keepAnsi
+        );
         expect(proc.stdout).contains(stdout);
         expect(proc.stderr).contains(stderr);
-        }
-      catch (e) {
+      } catch (e) {
         if (!isWindows()) {
           // ansible does not work on Windows, so we can't test it
           expect(e.code).equals(rc);
           expect(e.stderr).contains(stderr);
           expect(e.stderr).contains(stdout);
         }
-        }
-      });
+      }
     });
   });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
+    "esModuleInterop": true,
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2016"],


### PR DESCRIPTION
This makes runCommand automatically strip ANSI escapes from stdout and stderr, while still allowing user to opt-in for not stripping them.

- The reason for using stripping by default is that the primary use case for runCommand is to process the output and not to display it inside a terminal. This should prevent bugs where we fail to parse the output from various tools due to presence of ANSI codes.
- Includes changes to tests so it does verify both callings methods, with stripping and without stripping.
- We use `@electerm/strip-ansi` in particular because original `strip-eslint` does not work with `ts-node`, which is used when running mocha tests. I spent a good number of hours trying to make original strip-eslint to work with both runtime and during testing and failed. Feel free to check it yourself but be aware that there will be daemons as you will endup breaking either `npm run compile` or `npm run test`.

Related: https://github.com/ansible/vscode-ansible/issues/373
Closes: #183
Closes: #173