### PR TITLE
Reformat typescript using prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
     rev: "v2.5.1"
     hooks:
       - id: prettier
-        types: ["json"]
+        types_or: ["json", "ts"]
         exclude: >
           (?x)^(
             ansible-language-configuration.json|
@@ -92,11 +92,11 @@ repos:
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.30.0
     hooks:
-    - id: markdownlint
-      exclude: >
-        (?x)^
-          docs/changelog-fragments\.d/\d+\.\w+\.md
-        $
+      - id: markdownlint
+        exclude: >
+          (?x)^
+            docs/changelog-fragments\.d/\d+\.\w+\.md
+          $
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.6.0
     hooks:

--- a/src/services/ansibleConfig.ts
+++ b/src/services/ansibleConfig.ts
@@ -41,7 +41,9 @@ export class AnsibleConfig {
         (_, key) => key.substring(0, key.indexOf('(')) // remove config source in parenthesis
       );
       if (typeof config.COLLECTIONS_PATHS === 'string') {
-        this._collection_paths = parsePythonStringArray(config.COLLECTIONS_PATHS);
+        this._collection_paths = parsePythonStringArray(
+          config.COLLECTIONS_PATHS
+        );
       } else {
         this._collection_paths = [];
       }

--- a/src/services/executionEnvironment.ts
+++ b/src/services/executionEnvironment.ts
@@ -13,7 +13,7 @@ export class ExecutionEnvironment {
   private connection: Connection;
   private context: WorkspaceFolderContext;
   private useProgressTracker = false;
-  private successFileMarker = 'SUCCESS'
+  private successFileMarker = 'SUCCESS';
   private _container_engine: IContainerEngine;
   private _container_image: string;
   private _container_image_id: string;
@@ -177,7 +177,9 @@ export class ExecutionEnvironment {
         );
       }
       // plugin cache successfully created
-      fs.closeSync(fs.openSync(path.join(hostCacheBasePath, this.successFileMarker), 'w'));
+      fs.closeSync(
+        fs.openSync(path.join(hostCacheBasePath, this.successFileMarker), 'w')
+      );
     } catch (error) {
       this.connection.window.showErrorMessage(
         `Exception in ExecutionEnvironment service while fetching docs: ${JSON.stringify(
@@ -233,36 +235,40 @@ export class ExecutionEnvironment {
   }
 
   public cleanUpContainer(containerName: string): void {
-    const cleanUpCommands =  [
+    const cleanUpCommands = [
       `${this._container_engine} stop ${containerName}`,
       `${this._container_engine} rm ${containerName}`,
-    ]
+    ];
 
     if (!this.doesContainerNameExist(containerName)) {
-      console.log(`clean up container not required as container with name ${containerName} does not exist`);
-      return
+      console.log(
+        `clean up container not required as container with name ${containerName} does not exist`
+      );
+      return;
     }
-    for (const command of cleanUpCommands ){
+    for (const command of cleanUpCommands) {
       try {
         child_process.execSync(command, {
           cwd: URI.parse(this.context.workspaceFolder.uri).path,
         });
       } catch (error) {
         // container already stopped and/or removed
-        break
+        break;
       }
     }
   }
 
   public doesContainerNameExist(containerName: string): boolean {
-    let containerNameExist = false
+    let containerNameExist = false;
     try {
-      child_process.execSync(`${this._container_engine} inspect ${containerName}`);
-      containerNameExist = true
+      child_process.execSync(
+        `${this._container_engine} inspect ${containerName}`
+      );
+      containerNameExist = true;
     } catch (error) {
-      containerNameExist = false
+      containerNameExist = false;
     }
-    return containerNameExist
+    return containerNameExist;
   }
 
   private isPluginInPath(
@@ -357,7 +363,7 @@ export class ExecutionEnvironment {
   }
 
   private isPluginDocCacheValid(hostCacheBasePath: string) {
-    const markerFilePath = path.join(hostCacheBasePath, this.successFileMarker)
-    return true ? fs.existsSync(markerFilePath) : false
+    const markerFilePath = path.join(hostCacheBasePath, this.successFileMarker);
+    return true ? fs.existsSync(markerFilePath) : false;
   }
 }

--- a/src/services/settingsManager.ts
+++ b/src/services/settingsManager.ts
@@ -20,8 +20,8 @@ export class SettingsManager {
       containerEngine: 'auto',
       enabled: false,
       image: 'quay.io/ansible/creator-ee:latest',
-      pullPolicy: 'missing'
-    }
+      pullPolicy: 'missing',
+    },
   };
   private globalSettings: ExtensionSettings = this.defaultSettings;
 

--- a/src/services/workspaceManager.ts
+++ b/src/services/workspaceManager.ts
@@ -76,19 +76,23 @@ export class WorkspaceManager {
       }
     }
     /* *
-    * If control reaches at this point it indicates an individual file is
-    * opened in client without any workspace.
-    * Set the workspace to directory of the file pointed by uri.
-    */
-    const documentFolderPathParts = uri.split(path.sep)
-    documentFolderPathParts.pop()
+     * If control reaches at this point it indicates an individual file is
+     * opened in client without any workspace.
+     * Set the workspace to directory of the file pointed by uri.
+     */
+    const documentFolderPathParts = uri.split(path.sep);
+    documentFolderPathParts.pop();
     const workspaceFolder: WorkspaceFolder = {
-      'uri': documentFolderPathParts.join(path.sep),
-      'name': documentFolderPathParts[documentFolderPathParts.length - 1]
-    }
+      uri: documentFolderPathParts.join(path.sep),
+      name: documentFolderPathParts[documentFolderPathParts.length - 1],
+    };
 
-    this.connection.console.log(`workspace folder explicitly set to ${URI.parse(workspaceFolder.uri).path}`);
-    return workspaceFolder
+    this.connection.console.log(
+      `workspace folder explicitly set to ${
+        URI.parse(workspaceFolder.uri).path
+      }`
+    );
+    return workspaceFolder;
   }
 
   public handleWorkspaceChanged(event: WorkspaceFoldersChangeEvent): void {

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -31,9 +31,7 @@ export function hasOwnProperty<X, Y extends PropertyKey>(
 /**
  * Checks whether `obj` is a non-null object.
  */
-export function isObject<X>(
-  obj: X
-): obj is X & Record<PropertyKey, unknown> {
+export function isObject<X>(obj: X): obj is X & Record<PropertyKey, unknown> {
   return obj && typeof obj === 'object';
 }
 

--- a/test/utils/helper.ts
+++ b/test/utils/helper.ts
@@ -2,14 +2,10 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import * as path from 'path';
 import { promises as fs } from 'fs';
 
-
 export async function getDoc(filename: string): Promise<TextDocument> {
-  const file = await fs.readFile(
-    path.resolve('test', 'data', filename),
-    {
-      encoding: 'utf8',
-    }
-  );
+  const file = await fs.readFile(path.resolve('test', 'data', filename), {
+    encoding: 'utf8',
+  });
   return TextDocument.create('uri', 'ansible', 1, file);
 }
 

--- a/test/utils/runCommand.test.ts
+++ b/test/utils/runCommand.test.ts
@@ -4,19 +4,36 @@ import { WorkspaceManager } from '../../src/services/workspaceManager';
 import { createConnection } from 'vscode-languageserver/node';
 import { getDoc, isWindows } from './helper';
 
-
 describe('commandRunner', () => {
-
   const tests = [
-    { args: ['ansible-config', 'dump'], rc: 0, stdout: 'ANSIBLE_FORCE_COLOR', stderr: '' },
-    { args: ['ansible', '--version'], rc: 0, stdout: 'configured module search path', stderr: '' },
-    { args: ['ansible-lint', '--version'], rc: 0, stdout: 'using ansible', stderr: '' },
-    { args: ['ansible-playbook', 'missing-file'], rc: 1, stdout: '', stderr: 'ERROR! the playbook: missing-file could not be found' },
-  ]
+    {
+      args: ['ansible-config', 'dump'],
+      rc: 0,
+      stdout: 'ANSIBLE_FORCE_COLOR',
+      stderr: '',
+    },
+    {
+      args: ['ansible', '--version'],
+      rc: 0,
+      stdout: 'configured module search path',
+      stderr: '',
+    },
+    {
+      args: ['ansible-lint', '--version'],
+      rc: 0,
+      stdout: 'using ansible',
+      stderr: '',
+    },
+    {
+      args: ['ansible-playbook', 'missing-file'],
+      rc: 1,
+      stdout: '',
+      stderr: 'ERROR! the playbook: missing-file could not be found',
+    },
+  ];
 
   tests.forEach(({ args, rc, stdout, stderr }) => {
     it(`call ${args.join(' ')}`, async function () {
-
       this.timeout(10000);
       process.argv.push('--node-ipc');
       const connection = createConnection();
@@ -25,24 +42,22 @@ describe('commandRunner', () => {
       const context = workspaceManager.getContext(textDoc.uri);
       const settings = await context.documentSettings.get(textDoc.uri);
 
-      const commandRunner = new CommandRunner(
-        connection,
-        context,
-        settings
-      );
+      const commandRunner = new CommandRunner(connection, context, settings);
       try {
-        const proc = await commandRunner.runCommand(args[0], args.slice(1).join(' '));
+        const proc = await commandRunner.runCommand(
+          args[0],
+          args.slice(1).join(' ')
+        );
         expect(proc.stdout).contains(stdout);
         expect(proc.stderr).contains(stderr);
-        }
-      catch (e) {
+      } catch (e) {
         if (!isWindows()) {
           // ansible does not work on Windows, so we can't test it
           expect(e.code).equals(rc);
           expect(e.stderr).contains(stderr);
           expect(e.stderr).contains(stdout);
         }
-        }
-      });
+      }
     });
   });
+});

--- a/test/utils/yaml.test.ts
+++ b/test/utils/yaml.test.ts
@@ -27,11 +27,10 @@ async function getPathInFile(
 }
 
 describe('yaml', () => {
-
   beforeEach(function () {
     const brokenTests = new Map([
       // ['<testName>', '<url-of-tracking-issue>'],
-    ])
+    ]);
     const reason = brokenTests.get(this.currentTest.title);
     if (isWindows() && reason) {
       const msg = `Marked ${this.currentTest.title} as pending due to ${reason}`;


### PR DESCRIPTION
That enables typescript on pre-commit prettier run as currently almost any attempt
to edit .ts files using vscode would introduce undesired reformatting.
That is because we recommend prettier extension which auto-reformats.

The only manually made change is the one line in pre-commit config, the rest is just pre-commit itself.
