### PR TITLE
Fix test name for vscode-ansible extension test run

### DIFF
--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -42,9 +42,9 @@ jobs:
           popd
 
       - name: >-
-          Run test:ui with vscode-ansible
+          Run test-ui with vscode-ansible
         uses: GabrielBB/xvfb-action@v1
         with:
           run: >-
-            npm run test:ui
+            npm run test-ui
           working-directory: ../vscode-ansible


### PR DESCRIPTION
The PR on vscode-ansible https://github.com/ansible/vscode-ansible/pull/418
changed script name from `test:ui` to `test-ui`.
Updating the name to reflect in language server CI