### PR TITLE
Temporary disable test run on windows node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,6 +442,8 @@ jobs:
           node-version: 16
           os: macos-11
         # windows
+        # TODO: revisit this after windows + wsl2 node 
+        # is enabled in CI
         # - name: test-node12-windows
         #   node-version: 12
         #   os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,12 +442,12 @@ jobs:
           node-version: 16
           os: macos-11
         # windows
-        - name: test-node12-windows
-          node-version: 12
-          os: windows-latest
-        - name: test-node16-windows
-          node-version: 16
-          os: windows-latest
+        # - name: test-node12-windows
+        #   node-version: 12
+        #   os: windows-latest
+        # - name: test-node16-windows
+        #   node-version: 16
+        #   os: windows-latest
 
     continue-on-error: >-
       ${{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,7 @@ jobs:
           node-version: 16
           os: macos-11
         # windows
-        # TODO: revisit this after windows + wsl2 node 
+        # TODO: revisit this after windows + wsl2 node
         # is enabled in CI
         # - name: test-node12-windows
         #   node-version: 12


### PR DESCRIPTION
*  Currently tests are run on windows node
   without enabling WSL2 which is not supported
   test matrix
*  Currently work is in progress to add
   Windows + WSL2 combination https://github.com/ansible/vscode-ansible/pull/408
   in CI. After it is successfully done we will re-enable windows + wsl2
   node testing