### PR TITLE
ci: make prettier ignores consistent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,13 +82,6 @@ repos:
     rev: "v2.5.1"
     hooks:
       - id: prettier
-        types_or: ["json", "ts"]
-        exclude: >
-          (?x)^(
-            ansible-language-configuration.json|
-            jinja-language-configuration.json|
-            syntaxes/external/jinja.tmLanguage.json
-          )$
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.30.0
     hooks:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Untracked files, cannot symlink .gitignore due to:
+# https://github.com/prettier/prettier/issues/4708#issuecomment-1030581671
+.tox
+out
+
+# Tracked but externally sourced, no reformatting wanted:
+jinja-language-configuration.json
+syntaxes/external/jinja.tmLanguage.json
+
+# Files temporary excluded during prettier adoption:
+*.md
+*.yaml
+*.yml

--- a/bin/version-bump-allowed
+++ b/bin/version-bump-allowed
@@ -1,20 +1,17 @@
 #!/usr/bin/env node
 
-console.debug('Checking if it is allowed to bump the package version...')
+console.debug('Checking if it is allowed to bump the package version...');
 console.debug(
   `The previous package version was ${process.env.npm_package_version}`
-)
+);
 
 const isGitHubActionsCiCd =
-  process.env.CI === 'true' &&
-  process.env.GITHUB_ACTIONS === 'true'
+  process.env.CI === 'true' && process.env.GITHUB_ACTIONS === 'true';
 
 console.debug(
   `The package bump is ${
-      isGitHubActionsCiCd
-      ? ''
-      : 'not '
+    isGitHubActionsCiCd ? '' : 'not '
   }running under GitHub Actions CI/CD`
-)
+);
 
-process.exit(~~!isGitHubActionsCiCd)
+process.exit(~~!isGitHubActionsCiCd);


### PR DESCRIPTION
This ensures that prettier will reformat the same set of files
regardless if is run via `pre-commit`, `npx run prettier` or vscode.

Previous setup was forcing reformatting of all markdown and yaml files
on save with vscode, as they were not really excluded.
