### PR TITLE
ci: use prettier on markdown from repo root

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 # Untracked files, cannot symlink .gitignore due to:
 # https://github.com/prettier/prettier/issues/4708#issuecomment-1030581671
+.pytest_cache
 .tox
 out
 
@@ -8,6 +9,7 @@ jinja-language-configuration.json
 syntaxes/external/jinja.tmLanguage.json
 
 # Files temporary excluded during prettier adoption:
-*.md
+docs/**/*.md
+.github/**/*.md
 *.yaml
 *.yml

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -15,5 +15,10 @@ overrides:
       parser: json5
       quoteProps: preserve
       singleQuote: false
+  - files:
+      - '*.md'
+    options:
+      # compatibility with markdownlint
+      proseWrap: always
 semi: true
 singleQuote: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 <!-- markdownlint-disable no-duplicate-heading no-multiple-blanks -->
+
 # Change Log
 
-All notable changes to the Ansible VS Code extension will be documented in this file.
+All notable changes to the Ansible VS Code extension will be documented in this
+file.
 
 [//]: # DO-NOT-REMOVE-versioning-promise-START
 
@@ -21,47 +23,44 @@ https://github.com/ansible/ansible-language-server/tree/main/docs/changelog-frag
 
 <!-- towncrier release notes start -->
 
-
 ## v0.4.0 (2021-11-25)
 
 ### Bugfixes
 
-* Prevented throwing an unhandled exception caused by undefined linter
-  arguments settings (#142) {user}`ssbarnea`
-* Implemented opening standalone Ansible files that have no workspace
-  associated (#140) {user}`ganeshrn`
+- Prevented throwing an unhandled exception caused by undefined linter arguments
+  settings (#142) {user}`ssbarnea`
+- Implemented opening standalone Ansible files that have no workspace associated
+  (#140) {user}`ganeshrn`
 
 ## v0.3.0 (2021-11-18)
 
 ### Minor Changes
 
-* Added support for nested module options (suboptions) (#116)
-  {user}`tomaciazek`
-* Adopted use of `creator-ee` execution environment (#132)
-  {user}`ssbarnea`
-* Updated container cleanup logic for execution environment (#111)
+- Added support for nested module options (suboptions) (#116) {user}`tomaciazek`
+- Adopted use of `creator-ee` execution environment (#132) {user}`ssbarnea`
+- Updated container cleanup logic for execution environment (#111)
   {user}`ganeshrn`
 
 ### Bugfixes
 
-* Updated plugin doc cache validate logic for execution environment (#109)
+- Updated plugin doc cache validate logic for execution environment (#109)
   {user}`ganeshrn`
-* Fixed issue with container copy command (#110) {user}`ganeshrn`
+- Fixed issue with container copy command (#110) {user}`ganeshrn`
 
 ## v0.2.6 (2021-10-29)
 
 ### Bugfixes
 
-* Fixed auto-completion to account for the builtin modules when used
-  with EE (#94) {user}`ganeshrn`
+- Fixed auto-completion to account for the builtin modules when used with EE
+  (#94) {user}`ganeshrn`
 
 ## v0.2.5 (2021-10-23)
 
 ### Bugfixes
 
-* Added a guard for linting only playbook files with the Ansible's
-  built-in syntax-check when ansible-lint is unavailable. This is used for
-  providing the diagnostics information (#89) {user}`priyamsahoo`
+- Added a guard for linting only playbook files with the Ansible's built-in
+  syntax-check when ansible-lint is unavailable. This is used for providing the
+  diagnostics information (#89) {user}`priyamsahoo`
 
 ## v0.2.4 (2021-10-19)
 
@@ -69,53 +68,50 @@ https://github.com/ansible/ansible-language-server/tree/main/docs/changelog-frag
 
 The most notable changes that happened were:
 
-* Renaming and publishing the package under the `@ansible` scope on
-  Npmjs. The new name is `@ansible/ansible-language-server` now
-  (#10) {user}`webknjaz`
-* Deprecation of the initial `ansible-language-server` npm package that
-  existed in the global namespace prior to the rename {user}`ganeshrn`
-* Adding the auto-completion and diagnostics support for Ansible
-  Execution Environments {user}`ganeshrn`
+- Renaming and publishing the package under the `@ansible` scope on Npmjs. The
+  new name is `@ansible/ansible-language-server` now (#10) {user}`webknjaz`
+- Deprecation of the initial `ansible-language-server` npm package that existed
+  in the global namespace prior to the rename {user}`ganeshrn`
+- Adding the auto-completion and diagnostics support for Ansible Execution
+  Environments {user}`ganeshrn`
 
 ### Changes
 
-* Started falling back to checking playbooks with the Ansible's built-in
+- Started falling back to checking playbooks with the Ansible's built-in
   syntax-check when `ansible-lint` is not installed or disabled (#5)
   {user}`priyamsahoo`
-* Set the minimum runtime prerequisites to `npm > 7.11.2` and
-  `node >= 12` (#23) {user}`ssbarnea`
-* Updated the default settings value to use fully qualified collection
-  name (FQCN) during auto-completion (#37) {user}`priyamsahoo`
-* Added auto-completion support for Ansible Execution Environments
-  (#42 #54 #55) {user}`ganeshrn`
-* Added diagnostics support for Ansible Execution Environments (#53)
+- Set the minimum runtime prerequisites to `npm > 7.11.2` and `node >= 12` (#23)
+  {user}`ssbarnea`
+- Updated the default settings value to use fully qualified collection name
+  (FQCN) during auto-completion (#37) {user}`priyamsahoo`
+- Added auto-completion support for Ansible Execution Environments (#42 #54 #55)
   {user}`ganeshrn`
-* Updated module completion return statement to support sorting as per
-  FQCN (#57) {user}`priyamsahoo`
+- Added diagnostics support for Ansible Execution Environments (#53)
+  {user}`ganeshrn`
+- Updated module completion return statement to support sorting as per FQCN
+  (#57) {user}`priyamsahoo`
 
 ### Bugfixes
 
-* Added a fix to check that the module paths are directories before
-  globbing them during the documentation lookup (#38)
-  {user}`kimbernator`
-* Implemented documentation fragment discovery (#40) {user}`tomaciazek`
-* Fixed sort `slice()` exception issue in `ansibleConfig` service (#76)
+- Added a fix to check that the module paths are directories before globbing
+  them during the documentation lookup (#38) {user}`kimbernator`
+- Implemented documentation fragment discovery (#40) {user}`tomaciazek`
+- Fixed sort `slice()` exception issue in `ansibleConfig` service (#76)
   {user}`ssbarnea`
-* Fixed an issue with progress handling when `ansible-lint` falls back
-  to `syntax check` (#88) {user}`yaegassy`
+- Fixed an issue with progress handling when `ansible-lint` falls back to
+  `syntax check` (#88) {user}`yaegassy`
 
 ### Misc
 
-* Replaced `decode`/`encodeURI` with a native VS Code mechanism (#8)
+- Replaced `decode`/`encodeURI` with a native VS Code mechanism (#8)
   {user}`tomaciazek`
-* Implemented the release CD via `workflow_dispatch` (#65)
-  {user}`webknjaz`
+- Implemented the release CD via `workflow_dispatch` (#65) {user}`webknjaz`
 
 ## v0.1.0-1 (2021-07-28)
 
-* Updated the npm package to include the `out/` folder
+- Updated the npm package to include the `out/` folder
 
 ## v0.1.0 (2021-07-28)
 
-* Initial ansible language server release. Based on the `vscode-ansible` plugin
+- Initial ansible language server release. Based on the `vscode-ansible` plugin
   developed by {user}`Tomasz Maciążek <tomaciazek>`

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 This language server adds support for Ansible and is currently used by the
 following projects:
 
-* [Ansible extension for vscode/codium](https://github.com/ansible/vscode-ansible)
-* [Ansible extension for coc.nvim](https://github.com/yaegassy/coc-ansible)
+- [Ansible extension for vscode/codium](https://github.com/ansible/vscode-ansible)
+- [Ansible extension for coc.nvim](https://github.com/yaegassy/coc-ansible)
 
 ## Features
 
@@ -38,15 +38,15 @@ is provided instantaneously.
 
 On opening and saving a document, `ansible-lint` is executed in the background
 and any findings are presented as errors. You might find it useful that
-rules/tags added to `warn_list`
-(see [Ansible Lint Documentation](https://ansible-lint.readthedocs.io/en/latest/configuring.html))
+rules/tags added to `warn_list` (see
+[Ansible Lint Documentation](https://ansible-lint.readthedocs.io/en/latest/configuring.html))
 are shown as warnings instead.
 
 > If you also install `yamllint`, `ansible-lint` will detect it and incorporate
 > into the linting process. Any findings reported by `yamllint` will be exposed
 > in VSCode as errors/warnings.
 
-***Note***
+**_Note_**
 
 If `ansible-lint` is not installed/found or running `ansible-lint` results in
 error it will fallback to `ansible --syntax-check` for validation.
@@ -59,23 +59,23 @@ The extension tries to detect whether the cursor is on a play, block or task
 etc. and provides suggestions accordingly. There are also a few other rules that
 improve user experience:
 
-* the `name` property is always suggested first
-* on module options, the required properties are shown first, and aliases are
+- the `name` property is always suggested first
+- on module options, the required properties are shown first, and aliases are
   shown last, otherwise ordering from the documentation is preserved
-* FQCNs (fully qualified collection names) are inserted only when necessary;
+- FQCNs (fully qualified collection names) are inserted only when necessary;
   collections configured with the [`collections` keyword] are honored. This
   behavior can be disabled in extension settings.
 
 [`collections` keyword]:
-https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#simplifying-module-names-with-the-collections-keyword
+  https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#simplifying-module-names-with-the-collections-keyword
 
 #### Auto-closing Jinja expressions
 
 ![Easier Jinja expression typing](https://github.com/ansible/ansible-language-server/raw/main/images/jinja-expression.gif)
 
-When writing a Jinja expression, you only need to type `"{{<space>`, and it
-will be mirrored behind the cursor (including the space). You can also select
-the whole expression and press `space` to put spaces on both sides of the
+When writing a Jinja expression, you only need to type `"{{<space>`, and it will
+be mirrored behind the cursor (including the space). You can also select the
+whole expression and press `space` to put spaces on both sides of the
 expression.
 
 ### Documentation reference
@@ -90,47 +90,48 @@ the documentation straight from the Python implementation of the modules.
 
 ![Go to code on Ctrl+click](https://github.com/ansible/ansible-language-server/raw/main/images/go-to-definition.gif)
 
-You may also open the implementation of any module using the standard *Go to
-Definition* operation, for instance, by clicking on the module name while
+You may also open the implementation of any module using the standard _Go to
+Definition_ operation, for instance, by clicking on the module name while
 holding `ctrl`/`cmd`.
 
 ## Language Server Settings
 
 The following settings are supported.
 
-* `ansible.ansible.path`: Path to the `ansible` executable. Default is `ansible`,
-  which means $PATH is searched for the executable.
-* `ansible.ansible.useFullyQualifiedCollectionNames`: Toggles use of
-  fully qualified collection names (FQCN) when inserting a module name.
-  Disabling it will only use FQCNs when necessary, that is when the collection
-  is not configured for the task. Default is `true`.
-* `ansible.ansibleLint.arguments`: Optional command line arguments to be
-  appended to `ansible-lint` invocation. See `ansible-lint` documentation. Default
-  is empty string.
-* `ansible.ansibleLint.enabled`: Enables/disables use of `ansible-lint`. default
+- `ansible.ansible.path`: Path to the `ansible` executable. Default is
+  `ansible`, which means $PATH is searched for the executable.
+- `ansible.ansible.useFullyQualifiedCollectionNames`: Toggles use of fully
+  qualified collection names (FQCN) when inserting a module name. Disabling it
+  will only use FQCNs when necessary, that is when the collection is not
+  configured for the task. Default is `true`.
+- `ansible.ansibleLint.arguments`: Optional command line arguments to be
+  appended to `ansible-lint` invocation. See `ansible-lint` documentation.
+  Default is empty string.
+- `ansible.ansibleLint.enabled`: Enables/disables use of `ansible-lint`. default
   is `true`.
-* `ansible.ansibleLint.path`: Path to the `ansible-lint` executable. Default is
+- `ansible.ansibleLint.path`: Path to the `ansible-lint` executable. Default is
   `ansible-lint`, which means $PATH is searched for the executable.
-* `ansible.ansibleNavigator.path`: Path to the `ansible-navigator` executable.
-* `ansible.ansiblePlaybook.path`: Path to the `ansible-playbook` executable.
-* `ansible.executionEnvironment.containerEngine`: The container engine to be used
-  while running with execution environment. Valid values are `auto`, `podman` and
-  `docker`. For `auto` it will look for `podman` then `docker`. Default is `auto`.
-* `ansible.executionEnvironment.enabled`: Enable or disable the use of an
-   execution environment. Default is `false`.
-* `ansible.executionEnvironment.image`: Specify the name of the execution
+- `ansible.ansibleNavigator.path`: Path to the `ansible-navigator` executable.
+- `ansible.ansiblePlaybook.path`: Path to the `ansible-playbook` executable.
+- `ansible.executionEnvironment.containerEngine`: The container engine to be
+  used while running with execution environment. Valid values are `auto`,
+  `podman` and `docker`. For `auto` it will look for `podman` then `docker`.
+  Default is `auto`.
+- `ansible.executionEnvironment.enabled`: Enable or disable the use of an
+  execution environment. Default is `false`.
+- `ansible.executionEnvironment.image`: Specify the name of the execution
   environment image. Default is `quay.io/ansible/creator-ee:latest`.
-* `ansible.executionEnvironment.pullPolicy`: Specify the image pull policy.
+- `ansible.executionEnvironment.pullPolicy`: Specify the image pull policy.
   Valid values are `always`, `missing`, `never` and `tag`. Setting `always` will
-  always pull the image when extension is activated or reloaded. Default is `missing`.
-  Setting `missing` will pull if not locally available. Setting `never` will
-  never pull the image and setting tag will always pull if the image tag is
-  'latest', otherwise pull if not locally available.
-* `ansible.python.interpreterPath`: Path to the `python`/`python3` executable.
+  always pull the image when extension is activated or reloaded. Default is
+  `missing`. Setting `missing` will pull if not locally available. Setting
+  `never` will never pull the image and setting tag will always pull if the
+  image tag is 'latest', otherwise pull if not locally available.
+- `ansible.python.interpreterPath`: Path to the `python`/`python3` executable.
   This setting may be used to make the extension work with `ansible` and
   `ansible-lint` installations in a Python virtual environment. Default is empty
   string.
-* `ansible.python.activationScript`: Path to a custom `activate` script, which
+- `ansible.python.activationScript`: Path to a custom `activate` script, which
   will be used instead of the setting above to run in a Python virtual
   environment. Default is empty string.
 
@@ -140,29 +141,30 @@ For details on setting up development environment and debugging refer to the
 [development document].
 
 [development document]:
-https://github.com/ansible/ansible-language-server/blob/main/docs/development.md
+  https://github.com/ansible/ansible-language-server/blob/main/docs/development.md
 
 ## Requirements
 
-* [Ansible 2.9+](https://docs.ansible.com/ansible/latest/index.html)
-* [Ansible Lint](https://ansible-lint.readthedocs.io/en/latest/) (required,
+- [Ansible 2.9+](https://docs.ansible.com/ansible/latest/index.html)
+- [Ansible Lint](https://ansible-lint.readthedocs.io/en/latest/) (required,
   unless you disable linter support)
-* [yamllint](https://yamllint.readthedocs.io/en/stable/) (optional)
+- [yamllint](https://yamllint.readthedocs.io/en/stable/) (optional)
 
 For Windows users, this extension works perfectly well with extensions such as
 `Remote - WSL` and `Remote - Containers`.
 
 > If you have any other extension providing language support for Ansible, you
-  might need to uninstall it first.
+> might need to uninstall it first.
 
 ## Known limitations
 
-* The shorthand syntax for module options (key=value pairs) is not supported.
-* Only Jinja *expressions* inside Ansible YAML files are supported. In order to
+- The shorthand syntax for module options (key=value pairs) is not supported.
+- Only Jinja _expressions_ inside Ansible YAML files are supported. In order to
   have syntax highlighting of Jinja template files, you'll need to install other
   extension.
-* Jinja *blocks* (inside Ansible YAML files) are not supported yet.
+- Jinja _blocks_ (inside Ansible YAML files) are not supported yet.
 
 ## Credit
 
-Based on the good work done by [Tomasz Maciążek](https://github.com/tomaciazek/vscode-ansible)
+Based on the good work done by
+[Tomasz Maciążek](https://github.com/tomaciazek/vscode-ansible)


### PR DESCRIPTION
Reduce the excludes on .md so we format the root ones. We will deal with the other folders in follow-ups.

Please not the commit that enables this does not change any markdown by itself, the second commit is made by pre-commit.ci action.