### PR TITLE
ci: use prettier on github md files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -2,5 +2,4 @@
 
 Please see the official [Ansible Community Code of Conduct][coc].
 
-[coc]:
-https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
+[coc]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,8 +9,8 @@ In order to contribute, you'll need to:
 
 3. Send it to us as a PR.
 
-4. Iterate on your PR, incorporating the requested improvements
-   and participating in the discussions.
+4. Iterate on your PR, incorporating the requested improvements and
+   participating in the discussions.
 
 Prerequisites:
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,15 +2,14 @@
 
 ## Supported Versions
 
-Ansible Language Server does not backport security fixes only applying
-them to the main branch and making the next patch release in the stream.
+Ansible Language Server does not backport security fixes only applying them to
+the main branch and making the next patch release in the stream.
 
 ## Reporting a Vulnerability
 
-We encourage responsible disclosure practices for security
-vulnerabilities. Please read our [policies for reporting bugs][bug
-reports policy] if you want to report a security issue that might affect
-Ansible.
+We encourage responsible disclosure practices for security vulnerabilities.
+Please read our [policies for reporting bugs][bug reports policy] if you want to
+report a security issue that might affect Ansible.
 
 [bug reports policy]:
-https://docs.ansible.com/ansible/devel/community/reporting_bugs_and_features.html#reporting-a-bug
+  https://docs.ansible.com/ansible/devel/community/reporting_bugs_and_features.html#reporting-a-bug

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,5 @@ syntaxes/external/jinja.tmLanguage.json
 
 # Files temporary excluded during prettier adoption:
 docs/**/*.md
-.github/**/*.md
 *.yaml
 *.yml


### PR DESCRIPTION
Follow-Up: #215 

Increases the scope of markdown files prettier will clean-up to include the .github directory and includes changes to those files made by prettier.