### PR TITLE
ci: use prettier on docs md files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,7 +9,5 @@ jinja-language-configuration.json
 syntaxes/external/jinja.tmLanguage.json
 
 # Files temporary excluded during prettier adoption:
-docs/*.md
-docs/contributing/*.md
 *.yaml
 *.yml

--- a/docs/contributing/code_of_conduct.md
+++ b/docs/contributing/code_of_conduct.md
@@ -1,3 +1,5 @@
 <!-- markdownlint-disable first-line-heading -->
+
 ```{include} ../../.github/CODE_OF_CONDUCT.md
+
 ```

--- a/docs/contributing/guidelines.md
+++ b/docs/contributing/guidelines.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable first-line-heading -->
+
 ```{spelling}
 de
 facto
@@ -9,12 +10,13 @@ Towncrier
 ```
 
 ```{include} ../../.github/CONTRIBUTING.md
+
 ```
 
 # Contributing docs
 
-We use [Sphinx][sphinx] to generate our docs website. You can trigger
-the process locally by executing:
+We use [Sphinx][sphinx] to generate our docs website. You can trigger the
+process locally by executing:
 
 ```shell-session
 $ tox -e build-docs
@@ -38,21 +40,20 @@ _______________________________________________________ summary ________________
   congratulations :)
 ```
 
-It is also integrated with [Read The Docs][rtd] that builds and
-publishes each commit to the main branch and generates live
-docs previews for each pull request.
+It is also integrated with [Read The Docs][rtd] that builds and publishes each
+commit to the main branch and generates live docs previews for each pull
+request.
 
-The sources of the [Sphinx][sphinx] documents use reStructuredText as a
-de-facto standard. But in order to make contributing docs more
-beginner-friendly, we have integrated [MyST parser][myst] allowing us
-to also accept new documents written in an extended version of
-Markdown that supports using Sphinx directives and roles.
-{ref}`Read the docs <myst:intro/writing>` to learn more on how
-to use it.
+The sources of the [Sphinx][sphinx] documents use reStructuredText as a de-facto
+standard. But in order to make contributing docs more beginner-friendly, we have
+integrated [MyST parser][myst] allowing us to also accept new documents written
+in an extended version of Markdown that supports using Sphinx directives and
+roles. {ref}`Read the docs <myst:intro/writing>` to learn more on how to use it.
 
 [myst]: https://pypi.org/project/myst-parser/
 [rtd]: https://readthedocs.org
 [sphinx]: https://www.sphinx-doc.org
 
 ```{include} ../changelog-fragments.d/README.md
+
 ```

--- a/docs/contributing/security.md
+++ b/docs/contributing/security.md
@@ -1,7 +1,9 @@
 <!-- markdownlint-disable first-line-heading -->
+
 ```{spelling}
 backport
 ```
 
 ```{include} ../../.github/SECURITY.md
+
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,8 +4,8 @@
 
 A demo of the setup can be found [on youtube](https://youtu.be/LsvWsX7Mbo8).
 
-It is recommended to work on the forked copy of this repository from your
-github account to raise pull requests.
+It is recommended to work on the forked copy of this repository from your github
+account to raise pull requests.
 
 ```bash
 git clone git@github.com:<your-github-id>/ansible-language-server.git
@@ -17,17 +17,17 @@ git checkout -b <name_of_branch> upstream/main
 
 ## Running & debugging the language-server with VS Code
 
-* Install dependent packages within ansible-language-server root directory
+- Install dependent packages within ansible-language-server root directory
 
 ```console
 ansible-language-server$ npm install .
 ```
 
-This will install the dependent modules under `node_modules` folder within
-the current directory.
+This will install the dependent modules under `node_modules` folder within the
+current directory.
 
-* Clone the repository containing the VS Code extension code into the
-  `vscode-ansible` directory *next to* the root directory of this repository.
+- Clone the repository containing the VS Code extension code into the
+  `vscode-ansible` directory _next to_ the root directory of this repository.
 
 ```bash
 cd ..
@@ -35,31 +35,32 @@ git clone git@github.com:ansible/vscode-ansible.git
 cd vscode-ansible
 ```
 
-* Open a new VS Code window and add folder to workspace
+- Open a new VS Code window and add folder to workspace
   `File -> Add folder to workspace` and add `vscode-ansible` and
   `ansible-language-server` folders to the workspace
 
-* Once the language server and `vscode-ansible/` directory is prepared,
-  compile both client and server using command
+- Once the language server and `vscode-ansible/` directory is prepared, compile
+  both client and server using command
 
 ```bash
 npm run compile:withserver
 ```
 
-* In the Run and debug window select **Client + Server (source)** configuration
-  and start debugging `Run -> Start Debugging`. This will open up a new VS Code window
-  which is the `Extension development Host` window.
+- In the Run and debug window select **Client + Server (source)** configuration
+  and start debugging `Run -> Start Debugging`. This will open up a new VS Code
+  window which is the `Extension development Host` window.
 
-* In the `Extension development Host` window add a new folder that has ansible files.
+- In the `Extension development Host` window add a new folder that has ansible
+  files.
 
-* You can set the ansible-language-server settings by adding
+- You can set the ansible-language-server settings by adding
   `.vscode/settings.json` file under the root folder. Example settings:
 
 ```json
 {
-    "ansible.python.interpreterPath": "<change to python3 executable path>",
-    "ansible.ansible.path": "<change to ansible executable path>",
-    "ansibleServer.trace.server": "verbose"
+  "ansible.python.interpreterPath": "<change to python3 executable path>",
+  "ansible.ansible.path": "<change to ansible executable path>",
+  "ansibleServer.trace.server": "verbose"
 }
 ```
 
@@ -73,8 +74,9 @@ modes.
 ### Building server locally
 
 1. Install prerequisites:
-   * latest [Visual Studio Code](https://code.visualstudio.com/)
-   * [Node.js](https://nodejs.org/) v12.0.0 or higher
+
+   - latest [Visual Studio Code](https://code.visualstudio.com/)
+   - [Node.js](https://nodejs.org/) v12.0.0 or higher
 
 2. Fork and clone this repository
 


### PR DESCRIPTION
Follow-Up: #215

Increases the scope of markdown files prettier will clean-up to include the docs directory and includes changes to those files made by prettier.
