### PR TITLE
Reformat changelog fragments with prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ jinja-language-configuration.json
 syntaxes/external/jinja.tmLanguage.json
 
 # Files temporary excluded during prettier adoption:
-docs/**/*.md
+docs/*.md
+docs/contributing/*.md
 *.yaml
 *.yml

--- a/docs/changelog-fragments.d/161.misc.md
+++ b/docs/changelog-fragments.d/161.misc.md
@@ -1,4 +1,4 @@
-Added [Sphinx][sphinx] documentation generator and set up the CI
-infrastructure for it -- by {user}`webknjaz`
+Added [Sphinx][sphinx] documentation generator and set up the CI infrastructure
+for it -- by {user}`webknjaz`
 
 [sphinx]: https://github.com/twisted/towncrier

--- a/docs/changelog-fragments.d/164.doc.md
+++ b/docs/changelog-fragments.d/164.doc.md
@@ -1,5 +1,5 @@
-Dropped the brackets from the changelog titles for the release sections.
-We now don't strictly follow the release notes format suggested by
-[Keep a Changelog][keepachangelog] -- by {user}`webknjaz`
+Dropped the brackets from the changelog titles for the release sections. We now
+don't strictly follow the release notes format suggested by [Keep a
+Changelog][keepachangelog] -- by {user}`webknjaz`
 
 [keepachangelog]: https://keepachangelog.com/en/1.1.0/

--- a/docs/changelog-fragments.d/165.doc.md
+++ b/docs/changelog-fragments.d/165.doc.md
@@ -1,2 +1,2 @@
-Replaced all the credits in the changelog with a dedicated Sphinx role
--- by {user}`webknjaz`
+Replaced all the credits in the changelog with a dedicated Sphinx role -- by
+{user}`webknjaz`

--- a/docs/changelog-fragments.d/169.misc.md
+++ b/docs/changelog-fragments.d/169.misc.md
@@ -1,2 +1,2 @@
-Fixed a half-baked change in the GitHub Actions CI/CD workflow job
-that is used in branch protection -- by {user}`webknjaz`
+Fixed a half-baked change in the GitHub Actions CI/CD workflow job that is used
+in branch protection -- by {user}`webknjaz`

--- a/docs/changelog-fragments.d/README.md
+++ b/docs/changelog-fragments.d/README.md
@@ -4,48 +4,41 @@
 
 ## Adding change notes with your PRs
 
-It is very important to maintain a log for news of how
-updating to the new version of the software will affect
-end-users. This is why we enforce collection of the change
-fragment files in pull requests as per
-[Towncrier philosophy][towncrier-philosophy].
+It is very important to maintain a log for news of how updating to the new
+version of the software will affect end-users. This is why we enforce collection
+of the change fragment files in pull requests as per [Towncrier
+philosophy][towncrier-philosophy].
 
-The idea is that when somebody makes a change, they must record
-the bits that would affect end-users only including information
-that would be useful to them. Then, when the maintainers publish
-a new release, they'll automatically use these records to compose
-a change log for the respective version. It is important to
-understand that including unnecessary low-level implementation
-related details generates noise that is not particularly useful
-to the end-users most of the time. And so such details should be
-recorded in the Git history rather than a changelog.
+The idea is that when somebody makes a change, they must record the bits that
+would affect end-users only including information that would be useful to them.
+Then, when the maintainers publish a new release, they'll automatically use
+these records to compose a change log for the respective version. It is
+important to understand that including unnecessary low-level implementation
+related details generates noise that is not particularly useful to the end-users
+most of the time. And so such details should be recorded in the Git history
+rather than a changelog.
 
 ## Alright! So how do I add a news fragment?
 
 To submit a change note about your PR, add a text file into the
-`docs/changelog-fragments.d/` folder. It should contain an
-explanation of what applying this PR will change in the way
-end-users interact with the project. One sentence is usually
-enough but feel free to add as many details as you feel necessary
-for the users to understand what it means.
+`docs/changelog-fragments.d/` folder. It should contain an explanation of what
+applying this PR will change in the way end-users interact with the project. One
+sentence is usually enough but feel free to add as many details as you feel
+necessary for the users to understand what it means.
 
-**Use the past tense** for the text in your fragment because,
-combined with others, it will be a part of the "news digest"
-telling the readers **what changed** in a specific version of
-the library *since the previous version*. You should also use
-[MyST Markdown][myst-md] syntax for highlighting code (inline or block),
-linking parts of the docs or external sites.
-At the end, sign your change note by adding ```-- by
-{user}`github-username``` (replace `github-username` with
-your own!).
+**Use the past tense** for the text in your fragment because, combined with
+others, it will be a part of the "news digest" telling the readers **what
+changed** in a specific version of the library _since the previous version_. You
+should also use [MyST Markdown][myst-md] syntax for highlighting code (inline or
+block), linking parts of the docs or external sites. At the end, sign your
+change note by adding `` -- by {user}`github-username `` (replace
+`github-username` with your own!).
 
-Finally, name your file following the convention that Towncrier
-understands: it should start with the number of an issue or a
-PR followed by a dot, then add a patch type, like `feature`,
-`bugfix`, `doc`, `misc` etc., and add `.md` as a suffix. If you
-need to add more than one fragment, you may add an optional
-sequence number (delimited with another period) between the type
-and the suffix.
+Finally, name your file following the convention that Towncrier understands: it
+should start with the number of an issue or a PR followed by a dot, then add a
+patch type, like `feature`, `bugfix`, `doc`, `misc` etc., and add `.md` as a
+suffix. If you need to add more than one fragment, you may add an optional
+sequence number (delimited with another period) between the type and the suffix.
 
 ## Examples for changelog entries adding to your Pull Requests
 
@@ -58,15 +51,14 @@ Added a `{user}` role to Sphinx config -- by {user}`webknjaz`
 File `docs/changelog-fragments.d/116.feature.md`:
 
 ```md
-Added support for nested module options (suboptions)
--- by {user}`tomaciazek`
+Added support for nested module options (suboptions) -- by {user}`tomaciazek`
 ```
 
 File `docs/changelog-fragments.d/140.bugfix.md`:
 
 ```md
-Implemented opening standalone Ansible files that have no workspace
-associated -- by {user}`ganeshrn`
+Implemented opening standalone Ansible files that have no workspace associated
+-- by {user}`ganeshrn`
 ```
 
 ```{tip}
@@ -74,7 +66,6 @@ See `pyproject.toml` for all available categories
 (`tool.towncrier.type`).
 ```
 
-[myst-md]:
-https://myst-parser.rtfd.io/en/latest/syntax/syntax.html
+[myst-md]: https://myst-parser.rtfd.io/en/latest/syntax/syntax.html
 [towncrier-philosophy]:
-https://towncrier.rtfd.io/en/actual-freaking-docs/#philosophy
+  https://towncrier.rtfd.io/en/actual-freaking-docs/#philosophy


### PR DESCRIPTION
This should minimize the reformatting done by changelog generation, like we seen with https://github.com/ansible/ansible-language-server/pull/222