### PR TITLE
Separate wrapped issue/PR list @ changelog entries

### DIFF
--- a/docs/changelog-fragments.d/.CHANGELOG-TEMPLATE.md.j2
+++ b/docs/changelog-fragments.d/.CHANGELOG-TEMPLATE.md.j2
@@ -13,7 +13,8 @@
 
 {% for text, values in sections[section][category].items() %}
 * {{ text }}
-  ({{ values|join(',\n  ') }})
+
+  ({{- values | join(', ') | wordwrap(72 - 4) -}})
 {% endfor -%}
 
 {% else %}


### PR DESCRIPTION
This patch essentially makes sure that the issue list in the changelog entries is separated on Markdown level. This helps ensure that if a change note ends with something with syntactic significance, the issue/PR list doesn't get parsed as a part of it.

Here's a preview as a sanity check that the entries are now rendered correctly: https://als--227.org.readthedocs.build/en/227/changelog/#v0-4-1-dev82-g3cde4d6-d20220208-as-of-today-unreleased-draft.