### PR TITLE
Export yaml validation function to use it in the test cases

### DIFF
--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -93,7 +93,7 @@ export async function doValidate(
   return diagnosticsByFile;
 }
 
-function getYamlValidation(textDocument: TextDocument): Diagnostic[] {
+export function getYamlValidation(textDocument: TextDocument): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
   const yDocuments = parseAllDocuments(textDocument.getText(), {
     prettyErrors: false,


### PR DESCRIPTION
The PR adds capability for `getYamlValidation()` to get exported so that it can directly be used while writing the test cases.