### PR TITLE
Fix npm script name change in docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -43,7 +43,7 @@ cd vscode-ansible
   both client and server using command
 
 ```bash
-npm run compile:withserver
+npm run compile-withserver
 ```
 
 - In the Run and debug window select **Client + Server (source)** configuration


### PR DESCRIPTION
PR https://github.com/ansible/vscode-ansible/pull/418 introduced
name change from npm scripts. Update development docs to reflect
the same name.