### PR TITLE
Ensure that we have a prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "deps": "ncu -u && npm install",
     "lint": "npm ci && pre-commit run -a",
     "prepack": "npm ci && npm run compile",
+    "//prepare": "Prepare is needed for installation from source",
+    "prepare": "npm run compile",
     "preversion": "bin/version-bump-allowed",
     "watch": "tsc --watch -p .",
     "test": "nyc -s -a mocha && nyc report --check-coverage",


### PR DESCRIPTION
Prepare script is needed when installing package from source, so npm will know how to compile them.

Related: https://github.com/ansible/vscode-ansible/issues/441