### PR TITLE
Fix docs requirements

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,6 +1,7 @@
+MarkupSafe<2.1.0  # https://github.com/pallets/markupsafe/issues/282
 myst-parser[linkify] >= 0.15.1
 setuptools-scm >= 6.0.1
-Sphinx >= 4.1.2
+Sphinx >= 4.1.2, < 4.4.0  # https://github.com/sphinx-doc/sphinx/issues/10112
 sphinx-ansible-theme >= 0.8.0
 sphinx-favicon >= 0.2
 sphinx-js >= 3.1.2


### PR DESCRIPTION
Avoid two known bugs with newer versions of our dependencies.
There is no need to rebuild the lock file because it is already
highly-outdated.
