### PR TITLE
Fix minor docs build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vscode-ansible
 .tox
 .python-version
 __pycache__
+.temp

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ allowlist_externals =
 basepython = python3
 commands_pre =
   # Retrieve possibly missing commits:
-  -git fetch --unshallow
-  -git fetch --tags
+  - git fetch --unshallow
+  - git fetch --tags
 changedir = {toxinidir}/docs
 sphinx_entrypoint = {envpython} -m sphinx
 sphinx_common_args =


### PR DESCRIPTION
- tox 4 requires a space after `-` prefix (v3 works with both)
- .temp folder was not ignored (used by docs)
