### PR TITLE
Standardize documentation building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
         path: ${{ needs.pre-setup.outputs.tarball-artifact-name }}
 
   docs:
-    name: 📚 ${{ matrix.toxenv }}
+    name: docs
 
     runs-on: ${{ matrix.os }}-latest
     strategy:
@@ -331,9 +331,7 @@ jobs:
         - >-
           3.10
         toxenv:
-        - build-docs
-        - linkcheck-docs
-        - spellcheck-docs
+        - docs
       fail-fast: false
 
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ vscode-ansible
 .python-version
 __pycache__
 .temp
+UNKNOWN.egg-info

--- a/tox.ini
+++ b/tox.ini
@@ -6,47 +6,25 @@ skip_install = true
 
 
 [docs]
+# do not use continuation with vars, see https://github.com/tox-dev/tox/issues/2069
+sphinx_common_args =
+  -j auto {tty:--color} -a -n -W --keep-going -T -d "{temp_dir}/.doctrees" . "{envdir}/docs_out"
+
+[testenv:docs]
 allowlist_externals =
   git
-basepython = python3
+changedir = {toxinidir}/docs
 commands_pre =
   # Retrieve possibly missing commits:
   - git fetch --unshallow
   - git fetch --tags
-changedir = {toxinidir}/docs
-sphinx_entrypoint = {envpython} -m sphinx
-sphinx_common_args =
-  -j auto \
-  {tty:--color} \
-  -a \
-  -n \
-  -W --keep-going \
-  -T \
-  -d "{temp_dir}/.doctrees" \
-  . \
-  "{envdir}/docs_out"
-deps =
-  -r{toxinidir}/docs/requirements.txt
-  # FIXME: re-enable the "-r" + "-c" paradigm once the pip bug is fixed.
-  # Ref: https://github.com/pypa/pip/issues/9243
-  # -r{toxinidir}/docs/requirements.in
-  # -c{toxinidir}/docs/requirements.txt
-passenv =
-  SSH_AUTH_SOCK
-skip_install = true
-usedevelop = false
-
-
-[testenv:build-docs]
-allowlist_externals = {[docs]allowlist_externals}
-basepython = {[docs]basepython}
-changedir = {[docs]changedir}
-commands_pre = {[docs]commands_pre}
 commands =
-  {[docs]sphinx_entrypoint} -b html {[docs]sphinx_common_args}
+  {envpython} -m sphinx -b html {[docs]sphinx_common_args}
+  {envpython} -m sphinx -b linkcheck {[docs]sphinx_common_args}
+  {envpython} -m sphinx -b spelling {[docs]sphinx_common_args}
 
   # Print out the output docs dir and a way to serve html:
-  -{envpython} -c\
+  - {envpython} -c\
   'import pathlib;\
   docs_dir = pathlib.Path(r"{envdir}") / "docs_out";\
   index_file = docs_dir / "index.html";\
@@ -56,41 +34,18 @@ commands =
   \t$ python3 -m http.server --directory \
   \N\{QUOTATION MARK\}\{docs_dir\}\N\{QUOTATION MARK\} 0\n\n" +\
   "=" * 120)'
-deps = {[docs]deps}
+
+deps =
+  -r{toxinidir}/docs/requirements.txt
+  # FIXME: re-enable the "-r" + "-c" paradigm once the pip bug is fixed.
+  # Ref: https://github.com/pypa/pip/issues/9243
+  # -r{toxinidir}/docs/requirements.in
+  # -c{toxinidir}/docs/requirements.txt
 description = Build The Docs
-passenv = {[docs]passenv}
-skip_install = {[docs]skip_install}
-usedevelop = {[docs]usedevelop}
-
-
-[testenv:linkcheck-docs]
-allowlist_externals =
-  {[docs]allowlist_externals}
-basepython = {[testenv:build-docs]basepython}
-commands_pre = {[testenv:build-docs]commands_pre}
-commands =
-  {[docs]sphinx_entrypoint} -b linkcheck {[docs]sphinx_common_args}
-changedir = {[docs]changedir}
-deps = {[docs]deps}
-description = Linkcheck The Docs
-passenv = {[docs]passenv}
-skip_install = {[docs]skip_install}
-usedevelop = {[docs]usedevelop}
-
-
-[testenv:spellcheck-docs]
-allowlist_externals =
-  {[docs]allowlist_externals}
-basepython = {[testenv:build-docs]basepython}
-commands_pre = {[testenv:build-docs]commands_pre}
-commands =
-  {[docs]sphinx_entrypoint} -b spelling {[docs]sphinx_common_args}
-changedir = {[docs]changedir}
-deps = {[docs]deps}
-description = Spellcheck The Docs
-passenv = {[docs]passenv}
-skip_install = {[docs]skip_install}
-usedevelop = {[docs]usedevelop}
+passenv =
+  SSH_AUTH_SOCK
+skip_install = true
+usedevelop = false
 
 
 [testenv:make-changelog]


### PR DESCRIPTION
Use a single job and tox target for building documentation, just as we have with other devtools projects. Building documentation should be do with a single command, not a chain of them.

This also declutters the CI/CD pipelines, thus improving the the performace and reduce the resource waste.

Related: https://github.com/ansible-community/devtools/issues/5
