### PR TITLE
Simplify lint and docs runs on GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,26 +175,6 @@ jobs:
             || steps.scm-version.outputs.dist-version-for-filenames
         }}.md')
 
-  lint:
-    env:
-      PIP_DISABLE_PIP_VERSION_CHECK: "1"
-    runs-on: Ubuntu-latest
-    steps:
-    - name: Fetch the src snapshot
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-        ref: ${{ github.event.inputs.release-commitish }}
-    - name: Setup node
-      uses: actions/setup-node@v2
-    - name: Install dependencies
-      run: |
-        python -m pip install --user --upgrade pip
-        python -m pip install -r test-requirements.txt
-        npm ci
-    - name: npm run lint
-      run: npm run lint
-
   build:
     name: Build ${{ needs.pre-setup.outputs.git-tag }}
     needs:
@@ -319,8 +299,8 @@ jobs:
         name: npm-package-tarball
         path: ${{ needs.pre-setup.outputs.tarball-artifact-name }}
 
-  docs:
-    name: docs
+  tox:
+    name: ${{ matrix.toxenv }}
 
     runs-on: ${{ matrix.os }}-latest
     strategy:
@@ -332,12 +312,14 @@ jobs:
           3.10
         toxenv:
         - docs
+        - lint
       fail-fast: false
 
     env:
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
       PY_COLORS: 1
-      TOX_PARALLEL_NO_SPINNER: 1
       TOXENV: ${{ matrix.toxenv }}
+      TOX_PARALLEL_NO_SPINNER: 1
 
     steps:
     - name: >-
@@ -346,6 +328,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Setup node
+      if: contains(matrix.toxenv, 'lint')
+      uses: actions/setup-node@v2
+
     - name: >-
         Calculate Python interpreter version hash value
         for use in the cache key
@@ -548,8 +535,7 @@ jobs:
     if: always()
 
     needs:
-    - docs
-    - lint
+    - tox  # lint, docs
     - test
     # - vscode
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "compile": "tsc -p .",
     "coverage": "nyc report --reporter=text-lcov > out/coverage.lcov",
     "deps": "ncu -u && npm install",
-    "lint": "npm ci && pre-commit run -a",
+    "lint": "pre-commit run -a",
     "prepack": "npm ci && npm run compile",
     "//prepare": "Prepare is needed for installation from source",
     "prepare": "npm run compile",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 # spell-checker:ignore toxinidir passenv usedevelop testenv basepython envpython linkcheck changedir envdir envlist minversion toxworkdir posargs envname
 [tox]
 envlist =
+  lint
+  docs
 minversion = 3.21.0
 skip_install = true
 
@@ -9,6 +11,11 @@ skip_install = true
 # do not use continuation with vars, see https://github.com/tox-dev/tox/issues/2069
 sphinx_common_args =
   -j auto {tty:--color} -a -n -W --keep-going -T -d "{temp_dir}/.doctrees" . "{envdir}/docs_out"
+
+[testenv]
+passenv =
+  CI
+  GITHUB_ACTIONS
 
 [testenv:docs]
 allowlist_externals =
@@ -46,6 +53,16 @@ passenv =
   SSH_AUTH_SOCK
 skip_install = true
 usedevelop = false
+
+
+[testenv:lint]
+description = Run all linters
+deps =
+  pre-commit >= 2.17.0
+commands =
+  # Commands are the same as running `npm run lint`:
+  pre-commit run -a
+skip_install = true
 
 
 [testenv:make-changelog]


### PR DESCRIPTION
Reduce the size of CI pipeline by running `docs` and `lint` using tox, very similar to our Python projects.

From now linting can be performed using either `npm run lint` or `tox -e lint`, as they run the same thing.

It seems that using `tox` as a generic test runner has some net benefits over npm, even for JS/TS projects, for reasons like:

* Ability to list and document testing commands `tox -va`.
* Keep the CI testing closer to local testing. The more CI jobs that match tox environments we have, the easier is to run them locally.
* Sticking commands inside `package.json` scripts proved to be difficult as we cannot include comments and we cannot split long chained commands into multiple lines. Thus, we might want to minimize its use and keep it only for npm internals, avoiding its use for generic (user facing testing commands).
* Tox also has a very good matrix explosion, something that we might want to us to ease testing. Probably we could use it for the other npm jobs too, like testing with multiple npm versions.