### PR TITLE
Enable test runs using tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
-# spell-checker:ignore toxinidir passenv usedevelop testenv basepython envpython linkcheck changedir envdir envlist minversion toxworkdir posargs envname
+# spell-checker:ignore toxinidir passenv usedevelop testenv basepython envpython linkcheck changedir envdir envlist minversion toxworkdir posargs envname skipsdist setenv
 [tox]
 envlist =
   lint
   docs
+  test
 minversion = 3.21.0
 skip_install = true
-
+skipsdist = true
 
 [docs]
 # do not use continuation with vars, see https://github.com/tox-dev/tox/issues/2069
@@ -13,9 +14,46 @@ sphinx_common_args =
   -j auto {tty:--color} -a -n -W --keep-going -T -d "{temp_dir}/.doctrees" . "{envdir}/docs_out"
 
 [testenv]
+description =
+  Run tests
+  test-node12: with node 12
+  test-node14: with node 14
+  test-node16: with node 16
 passenv =
   CI
   GITHUB_ACTIONS
+  HOME
+  SSH_AUTH_SOCK
+  TERM
+setenv =
+  FORCE_COLOR=1
+  NODE_VERSION=stable
+  node12: NODE_VERSION=12
+  node14: NODE_VERSION=14
+  node16: NODE_VERSION=16
+allowlist_externals =
+  bash
+  node
+# Activation of node version is not persistent and nvm works only from
+# within `bash --login`, do not call nvm/npm/node without it under tox as
+# you might end-up using system version, if any
+commands_pre =
+  {node12,node14,node16}: bash --login -c "nvm install --latest-npm --default {env:NODE_VERSION}"
+commands_post =
+  # restore nvm default alias to stable version
+  {node12,node14,node16}: bash --login -c "nvm alias default stable"
+commands =
+  bash --login -c "npm run test"
+
+skip_install = true
+
+# keep them, so tox 3 can lists these as additional envs:
+[testenv:test-{node12,node14,node16}]
+description =
+  Run tests
+  test-node12: with node 12
+  test-node14: with node 14
+  test-node16: with node 16
 
 [testenv:docs]
 allowlist_externals =


### PR DESCRIPTION
This change adds tox target that do match github workflows names, making easier to reproduce results across machines.

```
$ tox -av
default environments:
lint            -> Run all linters
docs            -> Build The Docs
test            -> Run tests

additional environments:
test-node12     -> Run tests with node 12
test-node14     -> Run tests with node 14
test-node16     -> Run tests with node 16
make-changelog  -> Generate a changelog from fragments using Towncrier. Getting an unreleased changelog preview does not require extra arguments. When invoking to update the changelog, pass the desired version as an argument after `--`. For example, `tox -e make-changelog -- 1.3.2`.
check-changelog -> Check Towncrier change notes
draft-changelog -> Print out the Towncrier-managed change notes draft for the next release to stdout
```