### PR TITLE
Replace Number.MAX_SAFE_INTEGER with integer.MAX_VALUE

### DIFF
--- a/docs/changelog-fragments.d/261.feature.md
+++ b/docs/changelog-fragments.d/261.feature.md
@@ -1,0 +1,3 @@
+Replaced the value `2^53 - 1 (which is Number.MAX_SAFE_INTEGER)` with
+`2^31 - 1 (which is integer.MAX_VALUE)` to support extension clients that do
+handle 64-bit floating point IEEE 754 number by --{user}`priyamsahoo`.

--- a/src/services/ansibleLint.ts
+++ b/src/services/ansibleLint.ts
@@ -7,6 +7,7 @@ import {
   Diagnostic,
   DiagnosticSeverity,
   DidChangeWatchedFilesParams,
+  integer,
   Position,
   Range,
 } from 'vscode-languageserver';
@@ -197,7 +198,7 @@ export class AnsibleLint {
             };
             const end: Position = {
               line: begin_line - 1,
-              character: Number.MAX_SAFE_INTEGER,
+              character: integer.MAX_VALUE,
             };
             const range: Range = {
               start: start,

--- a/src/services/ansiblePlaybook.ts
+++ b/src/services/ansiblePlaybook.ts
@@ -5,6 +5,7 @@ import {
   Connection,
   Diagnostic,
   DiagnosticSeverity,
+  integer,
   Position,
   Range,
 } from 'vscode-languageserver';
@@ -134,7 +135,7 @@ export class AnsiblePlaybook {
     };
     const end: Position = {
       line: line - 1,
-      character: Number.MAX_SAFE_INTEGER,
+      character: integer.MAX_VALUE,
     };
     const range: Range = {
       start,

--- a/src/services/validationManager.ts
+++ b/src/services/validationManager.ts
@@ -2,6 +2,7 @@ import IntervalTree from '@flatten-js/interval-tree';
 import {
   Connection,
   Diagnostic,
+  integer,
   TextDocumentContentChangeEvent,
   TextDocuments,
 } from 'vscode-languageserver';
@@ -136,7 +137,7 @@ export class ValidationManager {
           if (displacement) {
             const displacedDiagnostics = diagnosticTree.search([
               change.range.start.line,
-              Number.MAX_SAFE_INTEGER,
+              integer.MAX_VALUE,
             ]);
             if (displacedDiagnostics) {
               for (const diagnostic of displacedDiagnostics as Array<Diagnostic>) {

--- a/test/providers/validationProvider.test.ts
+++ b/test/providers/validationProvider.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { Position } from 'vscode-languageserver';
+import { Position, integer } from 'vscode-languageserver';
 import {
   doValidate,
   getYamlValidation,
@@ -41,7 +41,7 @@ describe('doValidate()', () => {
                 start: { line: 4, character: 0 } as Position,
                 end: {
                   line: 4,
-                  character: Number.MAX_SAFE_INTEGER,
+                  character: integer.MAX_VALUE,
                 } as Position,
               },
               source: 'Ansible',
@@ -53,7 +53,7 @@ describe('doValidate()', () => {
                 start: { line: 6, character: 0 } as Position,
                 end: {
                   line: 6,
-                  character: Number.MAX_SAFE_INTEGER,
+                  character: integer.MAX_VALUE,
                 } as Position,
               },
               source: 'Ansible',
@@ -66,7 +66,7 @@ describe('doValidate()', () => {
                 start: { line: 9, character: 0 } as Position,
                 end: {
                   line: 9,
-                  character: Number.MAX_SAFE_INTEGER,
+                  character: integer.MAX_VALUE,
                 } as Position,
               },
               source: 'Ansible',
@@ -79,7 +79,7 @@ describe('doValidate()', () => {
                 start: { line: 14, character: 0 } as Position,
                 end: {
                   line: 14,
-                  character: Number.MAX_SAFE_INTEGER,
+                  character: integer.MAX_VALUE,
                 } as Position,
               },
               source: 'Ansible',
@@ -97,7 +97,7 @@ describe('doValidate()', () => {
                 start: { line: 0, character: 0 } as Position,
                 end: {
                   line: 0,
-                  character: Number.MAX_SAFE_INTEGER,
+                  character: integer.MAX_VALUE,
                 } as Position,
               },
               source: 'Ansible',
@@ -115,7 +115,7 @@ describe('doValidate()', () => {
                 start: { line: 0, character: 0 } as Position,
                 end: {
                   line: 0,
-                  character: Number.MAX_SAFE_INTEGER,
+                  character: integer.MAX_VALUE,
                 } as Position,
               },
               source: 'Ansible',
@@ -183,7 +183,7 @@ describe('doValidate()', () => {
                 start: { line: 0, character: 0 } as Position,
                 end: {
                   line: 0,
-                  character: Number.MAX_SAFE_INTEGER,
+                  character: integer.MAX_VALUE,
                 } as Position,
               },
               source: 'Ansible',
@@ -252,7 +252,7 @@ describe('doValidate()', () => {
                 start: { line: 0, character: 0 } as Position,
                 end: {
                   line: 0,
-                  character: Number.MAX_SAFE_INTEGER,
+                  character: integer.MAX_VALUE,
                 } as Position,
               },
               source: 'Ansible',
@@ -323,7 +323,7 @@ describe('doValidate()', () => {
                 start: { line: 0, character: 0 } as Position,
                 end: {
                   line: 0,
-                  character: Number.MAX_SAFE_INTEGER,
+                  character: integer.MAX_VALUE,
                 } as Position,
               },
               source: 'Ansible',


### PR DESCRIPTION
It has been found that some of the clients of ALS do not support large integer values from the server responses and therefore they are unable to produce desired results in their extensions. One such scenario is in the case of diagnostics report sent by the server.

The PR fixes the issue by replacing `Number.MAX_SAFE_INTEGER [ value: 9007199254740991 (2^53 − 1) ]` with `integer.MAX_VALUE [ value:  2147483647 (2^31 - 1) ]`.


Fixes: #218