### PR TITLE
Remove custom eslint/prettier single quote configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,6 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "eqeqeq": ["error", "smart"],
-    "prefer-template": "warn",
-    "quotes": ["warn", "single"]
+    "prefer-template": "warn"
   }
 }

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -21,4 +21,3 @@ overrides:
       # compatibility with markdownlint
       proseWrap: always
 semi: true
-singleQuote: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ https://github.com/ansible/ansible-language-server/tree/main/docs/changelog-frag
 
   [vscode-ansible#373]:
     https://github.com/ansible/vscode-ansible/issues/373
-    '{issue}`236`'
+    "{issue}`236`"
 
 ## v0.5.0 (2022-03-01)
 
@@ -62,7 +62,7 @@ https://github.com/ansible/ansible-language-server/tree/main/docs/changelog-frag
   now don't strictly follow the release notes format suggested by [Keep a
   Changelog][keepachangelog] -- by {user}`webknjaz`
 
-  [keepachangelog]: https://keepachangelog.com/en/1.1.0/ '{issue}`164`'
+  [keepachangelog]: https://keepachangelog.com/en/1.1.0/ "{issue}`164`"
 
 - Replaced all the credits in the changelog with a dedicated Sphinx role -- by
   {user}`webknjaz`
@@ -76,13 +76,13 @@ https://github.com/ansible/ansible-language-server/tree/main/docs/changelog-frag
 
   [towncrier]:
     https://github.com/twisted/towncrier
-    '{issue}`158`, {issue}`198`, {issue}`201`, {issue}`202`,
-{issue}`204`, {issue}`208`, {issue}`210`'
+    "{issue}`158`, {issue}`198`, {issue}`201`, {issue}`202`,
+{issue}`204`, {issue}`208`, {issue}`210`"
 
 - Added [Sphinx][sphinx] documentation generator and set up the CI
   infrastructure for it -- by {user}`webknjaz`
 
-  [sphinx]: https://github.com/twisted/towncrier '{issue}`161`'
+  [sphinx]: https://github.com/twisted/towncrier "{issue}`161`"
 
 - Added docs and references to the Community Code Of Conduct, security and
   contributing guides, and a pull request template -- by {user}`webknjaz`

--- a/bin/ansible-language-server
+++ b/bin/ansible-language-server
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../out/server/src/server.js');
+require("../out/server/src/server.js");

--- a/bin/version-bump-allowed
+++ b/bin/version-bump-allowed
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 
-console.debug('Checking if it is allowed to bump the package version...');
+console.debug("Checking if it is allowed to bump the package version...");
 console.debug(
   `The previous package version was ${process.env.npm_package_version}`
 );
 
 const isGitHubActionsCiCd =
-  process.env.CI === 'true' && process.env.GITHUB_ACTIONS === 'true';
+  process.env.CI === "true" && process.env.GITHUB_ACTIONS === "true";
 
 console.debug(
   `The package bump is ${
-    isGitHubActionsCiCd ? '' : 'not '
+    isGitHubActionsCiCd ? "" : "not "
   }running under GitHub Actions CI/CD`
 );
 

--- a/scripts/.eslintrc.js
+++ b/scripts/.eslintrc.js
@@ -1,34 +1,34 @@
 module.exports = {
   root: true,
-  parser: '@typescript-eslint/parser',
+  parser: "@typescript-eslint/parser",
   env: {
     node: true,
     es6: true,
   },
   parserOptions: {
-    sourceType: 'module',
+    sourceType: "module",
   },
-  plugins: ['@typescript-eslint', 'prettier'],
+  plugins: ["@typescript-eslint", "prettier"],
   extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
-    'prettier',
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
   ],
   rules: {
-    'prettier/prettier': 'error',
-    '@typescript-eslint/no-use-before-define': [
-      'error',
+    "prettier/prettier": "error",
+    "@typescript-eslint/no-use-before-define": [
+      "error",
       { functions: false, classes: false },
     ],
-    '@typescript-eslint/no-unused-vars': ['warn'],
-    '@typescript-eslint/explicit-function-return-type': [
+    "@typescript-eslint/no-unused-vars": ["warn"],
+    "@typescript-eslint/explicit-function-return-type": [
       1,
       { allowExpressions: true },
     ],
-    'eol-last': ['error'],
-    'space-infix-ops': ['error', { int32Hint: false }],
-    'no-multi-spaces': ['error', { ignoreEOLComments: true }],
-    'keyword-spacing': ['error'],
+    "eol-last": ["error"],
+    "space-infix-ops": ["error", { int32Hint: false }],
+    "no-multi-spaces": ["error", { ignoreEOLComments: true }],
+    "keyword-spacing": ["error"],
   },
 };

--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -7,13 +7,13 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const exit = require('process').exit;
-const dependencies = require('../package.json').dependencies;
+const exit = require("process").exit;
+const dependencies = require("../package.json").dependencies;
 
 for (const dep in dependencies) {
   if (Object.prototype.hasOwnProperty.call(dependencies, dep)) {
     const version = dependencies[dep];
-    if (version === 'next') {
+    if (version === "next") {
       console.error(
         `Dependency ${dep} has "${version}" version, please change it to fixed version`
       );

--- a/src/ansibleLanguageService.ts
+++ b/src/ansibleLanguageService.ts
@@ -6,22 +6,22 @@ import {
   InitializeResult,
   TextDocuments,
   TextDocumentSyncKind,
-} from 'vscode-languageserver';
-import { TextDocument } from 'vscode-languageserver-textdocument';
+} from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import {
   doCompletion,
   doCompletionResolve,
-} from './providers/completionProvider';
-import { getDefinition } from './providers/definitionProvider';
-import { doHover } from './providers/hoverProvider';
+} from "./providers/completionProvider";
+import { getDefinition } from "./providers/definitionProvider";
+import { doHover } from "./providers/hoverProvider";
 import {
   doSemanticTokens,
   tokenModifiers,
   tokenTypes,
-} from './providers/semanticTokenProvider';
-import { doValidate } from './providers/validationProvider';
-import { ValidationManager } from './services/validationManager';
-import { WorkspaceManager } from './services/workspaceManager';
+} from "./providers/semanticTokenProvider";
+import { doValidate } from "./providers/validationProvider";
+import { ValidationManager } from "./services/validationManager";
+import { WorkspaceManager } from "./services/workspaceManager";
 
 /**
  * Initializes the connection and registers all lifecycle event handlers.
@@ -61,7 +61,7 @@ export class AnsibleLanguageService {
           semanticTokensProvider: {
             documentSelector: [
               {
-                language: 'ansible',
+                language: "ansible",
               },
             ],
             full: true,
@@ -97,7 +97,7 @@ export class AnsibleLanguageService {
         this.connection.client.register(
           DidChangeConfigurationNotification.type,
           {
-            section: 'ansible',
+            section: "ansible",
           }
         );
       }
@@ -112,15 +112,15 @@ export class AnsibleLanguageService {
         watchers: [
           {
             // watch ansible configuration
-            globPattern: '**/ansible.cfg',
+            globPattern: "**/ansible.cfg",
           },
           {
             // watch ansible-lint configuration
-            globPattern: '**/.ansible-lint',
+            globPattern: "**/.ansible-lint",
           },
           {
             // watch role meta-configuration
-            globPattern: '**/meta/main.{yml,yaml}',
+            globPattern: "**/meta/main.{yml,yaml}",
           },
         ],
       });
@@ -134,7 +134,7 @@ export class AnsibleLanguageService {
           context.documentSettings.handleConfigurationChanged(params)
         );
       } catch (error) {
-        this.handleError(error, 'onDidChangeConfiguration');
+        this.handleError(error, "onDidChangeConfiguration");
       }
     });
 
@@ -152,7 +152,7 @@ export class AnsibleLanguageService {
           );
         }
       } catch (error) {
-        this.handleError(error, 'onDidOpen');
+        this.handleError(error, "onDidOpen");
       }
     });
 
@@ -164,7 +164,7 @@ export class AnsibleLanguageService {
           context.documentSettings.handleDocumentClosed(e.document.uri);
         }
       } catch (error) {
-        this.handleError(error, 'onDidClose');
+        this.handleError(error, "onDidClose");
       }
     });
 
@@ -174,7 +174,7 @@ export class AnsibleLanguageService {
           context.handleWatchedDocumentChange(params)
         );
       } catch (error) {
-        this.handleError(error, 'onDidChangeWatchedFiles');
+        this.handleError(error, "onDidChangeWatchedFiles");
       }
     });
 
@@ -192,7 +192,7 @@ export class AnsibleLanguageService {
           );
         }
       } catch (error) {
-        this.handleError(error, 'onDidSave');
+        this.handleError(error, "onDidSave");
       }
     });
 
@@ -203,7 +203,7 @@ export class AnsibleLanguageService {
           e.contentChanges
         );
       } catch (error) {
-        this.handleError(error, 'onDidChangeTextDocument');
+        this.handleError(error, "onDidChangeTextDocument");
       }
     });
 
@@ -217,7 +217,7 @@ export class AnsibleLanguageService {
           this.connection
         );
       } catch (error) {
-        this.handleError(error, 'onDidChangeContent');
+        this.handleError(error, "onDidChangeContent");
       }
     });
 
@@ -233,7 +233,7 @@ export class AnsibleLanguageService {
           }
         }
       } catch (error) {
-        this.handleError(error, 'onSemanticTokens');
+        this.handleError(error, "onSemanticTokens");
       }
       return {
         data: [],
@@ -256,7 +256,7 @@ export class AnsibleLanguageService {
           }
         }
       } catch (error) {
-        this.handleError(error, 'onHover');
+        this.handleError(error, "onHover");
       }
       return null;
     });
@@ -273,7 +273,7 @@ export class AnsibleLanguageService {
           }
         }
       } catch (error) {
-        this.handleError(error, 'onCompletion');
+        this.handleError(error, "onCompletion");
       }
       return null;
     });
@@ -289,7 +289,7 @@ export class AnsibleLanguageService {
           }
         }
       } catch (error) {
-        this.handleError(error, 'onCompletionResolve');
+        this.handleError(error, "onCompletionResolve");
       }
       return completionItem;
     });
@@ -310,7 +310,7 @@ export class AnsibleLanguageService {
           }
         }
       } catch (error) {
-        this.handleError(error, 'onDefinition');
+        this.handleError(error, "onDefinition");
       }
       return null;
     });
@@ -319,7 +319,7 @@ export class AnsibleLanguageService {
   private handleError(error: unknown, contextName: string) {
     const leadMessage = `An error occurred in '${contextName}' handler: `;
     if (error instanceof Error) {
-      const stack = error.stack ? `\n${error.stack}` : '';
+      const stack = error.stack ? `\n${error.stack}` : "";
       this.connection.console.error(
         `${leadMessage}[${error.name}] ${error.message}${stack}`
       );

--- a/src/interfaces/extensionSettings.ts
+++ b/src/interfaces/extensionSettings.ts
@@ -1,6 +1,6 @@
-export type IContainerEngine = 'auto' | 'podman' | 'docker';
+export type IContainerEngine = "auto" | "podman" | "docker";
 
-export type IPullPolicy = 'always' | 'missing' | 'never' | 'tag';
+export type IPullPolicy = "always" | "missing" | "never" | "tag";
 
 export interface ExtensionSettings {
   ansible: { path: string; useFullyQualifiedCollectionNames: boolean };

--- a/src/interfaces/module.ts
+++ b/src/interfaces/module.ts
@@ -1,4 +1,4 @@
-import { YAMLError } from 'yaml/util';
+import { YAMLError } from "yaml/util";
 
 export type IDescription = string | Array<unknown>;
 

--- a/src/interfaces/pluginRouting.ts
+++ b/src/interfaces/pluginRouting.ts
@@ -1,6 +1,6 @@
 export type IPluginRoutingByCollection = Map<string, IPluginRoutesByType>;
 
-export type IPluginTypes = 'modules'; // currently only modules are supported
+export type IPluginTypes = "modules"; // currently only modules are supported
 
 export type IPluginRoutesByType = Map<IPluginTypes, IPluginRoutesByName>;
 

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -4,20 +4,20 @@ import {
   MarkupContent,
   Range,
   TextEdit,
-} from 'vscode-languageserver';
-import { Position, TextDocument } from 'vscode-languageserver-textdocument';
-import { Node, Scalar, YAMLMap } from 'yaml/types';
-import { IOption } from '../interfaces/module';
-import { WorkspaceFolderContext } from '../services/workspaceManager';
+} from "vscode-languageserver";
+import { Position, TextDocument } from "vscode-languageserver-textdocument";
+import { Node, Scalar, YAMLMap } from "yaml/types";
+import { IOption } from "../interfaces/module";
+import { WorkspaceFolderContext } from "../services/workspaceManager";
 import {
   blockKeywords,
   playKeywords,
   playWithoutTaskKeywords,
   roleKeywords,
   taskKeywords,
-} from '../utils/ansible';
-import { formatModule, formatOption, getDetails } from '../utils/docsFormatter';
-import { insert, toLspRange } from '../utils/misc';
+} from "../utils/ansible";
+import { formatModule, formatOption, getDetails } from "../utils/docsFormatter";
+import { insert, toLspRange } from "../utils/misc";
 import {
   AncestryBuilder,
   findProvidedModule,
@@ -31,7 +31,7 @@ import {
   isTaskParam,
   parseAllDocuments,
   getPossibleOptionsForPath,
-} from '../utils/yaml';
+} from "../utils/yaml";
 
 const priorityMap = {
   nameKeyword: 1,
@@ -55,7 +55,7 @@ export async function doCompletion(
   // This is particularly important when parser has nothing more than
   // indentation to determine the scope of the current line. `_:` is ok here,
   // since we expect to work on a Pair level
-  preparedText = insert(preparedText, offset, '_:');
+  preparedText = insert(preparedText, offset, "_:");
   const yamlDocs = parseAllDocuments(preparedText);
 
   const useFqcn = (await context.documentSettings.get(document.uri)).ansible
@@ -112,7 +112,7 @@ export async function doCompletion(
               document,
               position,
               path,
-              new Map([['block', blockKeywords.get('block') as string]])
+              new Map([["block", blockKeywords.get("block") as string]])
             )
           );
 
@@ -123,7 +123,7 @@ export async function doCompletion(
           if (nodeRange) {
             textEdit = {
               range: nodeRange,
-              newText: '', // placeholder
+              newText: "", // placeholder
             };
           }
 
@@ -138,7 +138,7 @@ export async function doCompletion(
                 priority = priorityMap.moduleName;
                 kind = CompletionItemKind.Class;
               }
-              const [namespace, collection, name] = moduleFqcn.split('.');
+              const [namespace, collection, name] = moduleFqcn.split(".");
               return {
                 label: useFqcn ? moduleFqcn : name,
                 kind: kind,
@@ -254,7 +254,7 @@ function getKeywordCompletion(
   const nodeRange = getNodeRange(path[path.length - 1], document);
   return remainingParams.map(([keyword, description]) => {
     const priority =
-      keyword === 'name' ? priorityMap.nameKeyword : priorityMap.keyword;
+      keyword === "name" ? priorityMap.nameKeyword : priorityMap.keyword;
     const completionItem: CompletionItem = {
       label: keyword,
       kind: CompletionItemKind.Property,
@@ -282,11 +282,11 @@ function getKeywordCompletion(
  */
 function getNodeRange(node: Node, document: TextDocument): Range | undefined {
   const range = getOrigRange(node);
-  if (range && node instanceof Scalar && typeof node.value === 'string') {
+  if (range && node instanceof Scalar && typeof node.value === "string") {
     const start = range[0];
     let end = range[1];
     // compensate for `_:`
-    if (node.value.includes('_:')) {
+    if (node.value.includes("_:")) {
       end -= 2;
     } else {
       // colon, being at the end of the line, was excluded from the node
@@ -310,7 +310,7 @@ export async function doCompletionResolve(
 
     if (module && module.documentation) {
       const [namespace, collection, name] =
-        completionItem.data.moduleFqcn.split('.');
+        completionItem.data.moduleFqcn.split(".");
 
       let useFqcn = (
         await context.documentSettings.get(completionItem.data.documentUri)
@@ -321,7 +321,7 @@ export async function doCompletionResolve(
 
         const declaredCollections: Array<string> =
           completionItem.data?.inlineCollections || [];
-        declaredCollections.push('ansible.builtin');
+        declaredCollections.push("ansible.builtin");
 
         const metadata = await context.documentMetadata.get(
           completionItem.data.documentUri
@@ -368,5 +368,5 @@ function atEndOfLine(document: TextDocument, position: Position): boolean {
   const charAfterCursor = `${document.getText()}\n`[
     document.offsetAt(position)
   ];
-  return charAfterCursor === '\n' || charAfterCursor === '\r';
+  return charAfterCursor === "\n" || charAfterCursor === "\r";
 }

--- a/src/providers/definitionProvider.ts
+++ b/src/providers/definitionProvider.ts
@@ -1,15 +1,15 @@
-import { DefinitionLink, Range } from 'vscode-languageserver';
-import { Position, TextDocument } from 'vscode-languageserver-textdocument';
-import { Scalar } from 'yaml/types';
-import { DocsLibrary } from '../services/docsLibrary';
-import { toLspRange } from '../utils/misc';
+import { DefinitionLink, Range } from "vscode-languageserver";
+import { Position, TextDocument } from "vscode-languageserver-textdocument";
+import { Scalar } from "yaml/types";
+import { DocsLibrary } from "../services/docsLibrary";
+import { toLspRange } from "../utils/misc";
 import {
   AncestryBuilder,
   getOrigRange,
   getPathAt,
   isTaskParam,
   parseAllDocuments,
-} from '../utils/yaml';
+} from "../utils/yaml";
 
 export async function getDefinition(
   document: TextDocument,

--- a/src/providers/hoverProvider.ts
+++ b/src/providers/hoverProvider.ts
@@ -1,20 +1,20 @@
-import { Hover, MarkupContent, MarkupKind } from 'vscode-languageserver';
-import { Position, TextDocument } from 'vscode-languageserver-textdocument';
-import { Scalar } from 'yaml/types';
-import { DocsLibrary } from '../services/docsLibrary';
+import { Hover, MarkupContent, MarkupKind } from "vscode-languageserver";
+import { Position, TextDocument } from "vscode-languageserver-textdocument";
+import { Scalar } from "yaml/types";
+import { DocsLibrary } from "../services/docsLibrary";
 import {
   blockKeywords,
   isTaskKeyword,
   playKeywords,
   roleKeywords,
   taskKeywords,
-} from '../utils/ansible';
+} from "../utils/ansible";
 import {
   formatModule,
   formatOption,
   formatTombstone,
-} from '../utils/docsFormatter';
-import { toLspRange } from '../utils/misc';
+} from "../utils/docsFormatter";
+import { toLspRange } from "../utils/misc";
 import {
   AncestryBuilder,
   getOrigRange,
@@ -25,7 +25,7 @@ import {
   isRoleParam,
   isTaskParam,
   parseAllDocuments,
-} from '../utils/yaml';
+} from "../utils/yaml";
 
 export async function doHover(
   document: TextDocument,
@@ -110,7 +110,7 @@ function getKeywordHover(
 ): Hover | null {
   const keywordDocumentation = keywords.get(node.value);
   const markupDoc =
-    typeof keywordDocumentation === 'string'
+    typeof keywordDocumentation === "string"
       ? {
           kind: MarkupKind.Markdown,
           value: keywordDocumentation,

--- a/src/providers/semanticTokenProvider.ts
+++ b/src/providers/semanticTokenProvider.ts
@@ -3,17 +3,17 @@ import {
   SemanticTokens,
   SemanticTokensBuilder,
   SemanticTokenTypes,
-} from 'vscode-languageserver';
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import { Node, Pair, Scalar, YAMLMap, YAMLSeq } from 'yaml/types';
-import { IOption } from '../interfaces/module';
-import { DocsLibrary } from '../services/docsLibrary';
+} from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { Node, Pair, Scalar, YAMLMap, YAMLSeq } from "yaml/types";
+import { IOption } from "../interfaces/module";
+import { DocsLibrary } from "../services/docsLibrary";
 import {
   blockKeywords,
   isTaskKeyword,
   playKeywords,
   roleKeywords,
-} from '../utils/ansible';
+} from "../utils/ansible";
 import {
   findProvidedModule,
   getOrigRange,
@@ -22,7 +22,7 @@ import {
   isRoleParam,
   isTaskParam,
   parseAllDocuments,
-} from '../utils/yaml';
+} from "../utils/yaml";
 
 export const tokenTypes = [
   SemanticTokenTypes.method,
@@ -81,7 +81,7 @@ async function markSemanticTokens(
         } else if (isTaskParam(keyPath)) {
           if (isTaskKeyword(pair.key.value)) {
             markKeyword(pair.key, builder, document);
-            if (pair.key.value === 'args') {
+            if (pair.key.value === "args") {
               const module = await findProvidedModule(
                 path.concat(pair, pair.key),
                 document,
@@ -179,7 +179,7 @@ function markModuleParameters(
           document
         );
         if (
-          option.type === 'dict' &&
+          option.type === "dict" &&
           moduleParamPair.value instanceof YAMLMap
         ) {
           // highlight sub-parameters
@@ -190,7 +190,7 @@ function markModuleParameters(
             document
           );
         } else if (
-          option.type === 'list' &&
+          option.type === "list" &&
           moduleParamPair.value instanceof YAMLSeq
         ) {
           // highlight list of sub-parameters

--- a/src/providers/validationProvider.ts
+++ b/src/providers/validationProvider.ts
@@ -1,5 +1,5 @@
-import IntervalTree from '@flatten-js/interval-tree';
-import * as _ from 'lodash';
+import IntervalTree from "@flatten-js/interval-tree";
+import * as _ from "lodash";
 import {
   Connection,
   Diagnostic,
@@ -7,12 +7,12 @@ import {
   DiagnosticSeverity,
   Location,
   Range,
-} from 'vscode-languageserver';
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import { ValidationManager } from '../services/validationManager';
-import { WorkspaceFolderContext } from '../services/workspaceManager';
-import { isPlaybook, parseAllDocuments } from '../utils/yaml';
-import { CommandRunner } from '../utils/commandRunner';
+} from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { ValidationManager } from "../services/validationManager";
+import { WorkspaceFolderContext } from "../services/workspaceManager";
+import { isPlaybook, parseAllDocuments } from "../utils/yaml";
+import { CommandRunner } from "../utils/commandRunner";
 
 /**
  * Validates the given document.
@@ -40,15 +40,15 @@ export async function doValidate(
     const settings = await context.documentSettings.get(textDocument.uri);
     const commandRunner = new CommandRunner(connection, context, settings);
     const lintExecutable = settings.executionEnvironment.enabled
-      ? 'ansible-lint'
+      ? "ansible-lint"
       : settings.ansibleLint.path;
     const lintAvailability = await commandRunner.getExecutablePath(
       lintExecutable
     );
-    console.debug('Path for lint: ', lintAvailability);
+    console.debug("Path for lint: ", lintAvailability);
 
     if (lintAvailability) {
-      console.debug('Validating using ansible-lint');
+      console.debug("Validating using ansible-lint");
       diagnosticsByFile = await context.ansibleLint.doValidate(textDocument);
     }
 
@@ -56,21 +56,21 @@ export async function doValidate(
       // Notifying the user about the failed ansible-lint command and falling back to ansible syntax-check in this scenario
       if (diagnosticsByFile === -1) {
         console.debug(
-          'Ansible-lint command execution failed. Falling back to ansible syntax-check'
+          "Ansible-lint command execution failed. Falling back to ansible syntax-check"
         );
         connection?.window.showInformationMessage(
-          'Falling back to ansible syntax-check.'
+          "Falling back to ansible syntax-check."
         );
       }
-      console.debug('Validating using ansible syntax-check');
+      console.debug("Validating using ansible syntax-check");
 
       if (isPlaybook(textDocument)) {
-        console.log('is playbook...');
+        console.log("is playbook...");
         diagnosticsByFile = await context.ansiblePlaybook.doValidate(
           textDocument
         );
       } else {
-        console.log('not a playbook...');
+        console.log("not a playbook...");
         diagnosticsByFile = new Map();
       }
     }
@@ -116,12 +116,12 @@ export function getYamlValidation(textDocument: TextDocument): Diagnostic[] {
 
         let severity;
         switch (error.name) {
-          case 'YAMLReferenceError':
-          case 'YAMLSemanticError':
-          case 'YAMLSyntaxError':
+          case "YAMLReferenceError":
+          case "YAMLSemanticError":
+          case "YAMLSyntaxError":
             severity = DiagnosticSeverity.Error;
             break;
-          case 'YAMLWarning':
+          case "YAMLWarning":
             severity = DiagnosticSeverity.Warning;
             break;
           default:
@@ -132,7 +132,7 @@ export function getYamlValidation(textDocument: TextDocument): Diagnostic[] {
           message: error.message,
           range: range || Range.create(0, 0, 0, 0),
           severity: severity,
-          source: 'Ansible [YAML]',
+          source: "Ansible [YAML]",
         });
       }
     });
@@ -157,7 +157,7 @@ export function getYamlValidation(textDocument: TextDocument): Diagnostic[] {
               start: range.end,
               end: range.end,
             }),
-            'the scope of this error ends here'
+            "the scope of this error ends here"
           ),
         ];
         // collapse the range

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TextDocument } from "vscode-languageserver-textdocument";
 import {
   Connection,
   createConnection,
@@ -6,9 +6,9 @@ import {
   NotificationHandler,
   ProposedFeatures,
   TextDocuments,
-} from 'vscode-languageserver/node';
-import { AnsibleLanguageService } from './ansibleLanguageService';
-import { getUnsupportedError } from './utils/misc';
+} from "vscode-languageserver/node";
+import { AnsibleLanguageService } from "./ansibleLanguageService";
+import { getUnsupportedError } from "./utils/misc";
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -18,7 +18,7 @@ const connection: Connection = createConnection(ProposedFeatures.all);
 // error message to the client if so.
 const errorMessage = getUnsupportedError();
 if (errorMessage) {
-  connection.sendNotification('ansible/errorMessage', errorMessage);
+  connection.sendNotification("ansible/errorMessage", errorMessage);
 }
 
 const docChangeHandlers: NotificationHandler<DidChangeTextDocumentParams>[] =
@@ -35,7 +35,7 @@ connection.onDidChangeTextDocument((params) => {
 // overrides, such as `onDidChangeTextDocument`.
 const connectionProxy = new Proxy(connection, {
   get: (target, p, receiver) => {
-    if (p === 'onDidChangeTextDocument') {
+    if (p === "onDidChangeTextDocument") {
       return (handler: NotificationHandler<DidChangeTextDocumentParams>) => {
         docChangeHandlers.push(handler);
       };

--- a/src/services/ansibleConfig.ts
+++ b/src/services/ansibleConfig.ts
@@ -1,16 +1,16 @@
-import * as ini from 'ini';
-import * as _ from 'lodash';
-import * as path from 'path';
-import { Connection } from 'vscode-languageserver';
-import { WorkspaceFolderContext } from './workspaceManager';
-import { CommandRunner } from '../utils/commandRunner';
+import * as ini from "ini";
+import * as _ from "lodash";
+import * as path from "path";
+import { Connection } from "vscode-languageserver";
+import { WorkspaceFolderContext } from "./workspaceManager";
+import { CommandRunner } from "../utils/commandRunner";
 
 export class AnsibleConfig {
   private connection: Connection;
   private context: WorkspaceFolderContext;
   private _collection_paths: string[] = [];
   private _module_locations: string[] = [];
-  private _ansible_location = '';
+  private _ansible_location = "";
 
   constructor(connection: Connection, context: WorkspaceFolderContext) {
     this.connection = connection;
@@ -31,16 +31,16 @@ export class AnsibleConfig {
 
       // get Ansible configuration
       const ansibleConfigResult = await commandRunner.runCommand(
-        'ansible-config',
-        'dump'
+        "ansible-config",
+        "dump"
       );
 
       let config = ini.parse(ansibleConfigResult.stdout);
       config = _.mapKeys(
         config,
-        (_, key) => key.substring(0, key.indexOf('(')) // remove config source in parenthesis
+        (_, key) => key.substring(0, key.indexOf("(")) // remove config source in parenthesis
       );
-      if (typeof config.COLLECTIONS_PATHS === 'string') {
+      if (typeof config.COLLECTIONS_PATHS === "string") {
         this._collection_paths = parsePythonStringArray(
           config.COLLECTIONS_PATHS
         );
@@ -50,24 +50,24 @@ export class AnsibleConfig {
 
       // get Ansible basic information
       const ansibleVersionResult = await commandRunner.runCommand(
-        'ansible',
-        '--version'
+        "ansible",
+        "--version"
       );
 
       const versionInfo = ini.parse(ansibleVersionResult.stdout);
       this._module_locations = parsePythonStringArray(
-        versionInfo['configured module search path']
+        versionInfo["configured module search path"]
       );
       this._module_locations.push(
-        path.resolve(versionInfo['ansible python module location'], 'modules')
+        path.resolve(versionInfo["ansible python module location"], "modules")
       );
 
-      this._ansible_location = versionInfo['ansible python module location'];
+      this._ansible_location = versionInfo["ansible python module location"];
 
       // get Python sys.path
       // this is needed to get the pre-installed collections to work
       const pythonPathResult = await commandRunner.runCommand(
-        'python3',
+        "python3",
         ' -c "import sys; print(sys.path, end=\\"\\")"'
       );
       this._collection_paths.push(
@@ -107,6 +107,6 @@ export class AnsibleConfig {
 
 function parsePythonStringArray(string_list: string): string[] {
   const cleaned_str = string_list.slice(1, string_list.length - 1); // remove []
-  const quoted_elements = cleaned_str.split(',').map((e) => e.trim());
+  const quoted_elements = cleaned_str.split(",").map((e) => e.trim());
   return quoted_elements.map((e) => e.slice(1, e.length - 1));
 }

--- a/src/services/ansibleLint.ts
+++ b/src/services/ansibleLint.ts
@@ -1,7 +1,7 @@
-import { ExecException } from 'child_process';
-import { promises as fs } from 'fs';
-import * as path from 'path';
-import { URI } from 'vscode-uri';
+import { ExecException } from "child_process";
+import { promises as fs } from "fs";
+import * as path from "path";
+import { URI } from "vscode-uri";
 import {
   Connection,
   Diagnostic,
@@ -10,13 +10,13 @@ import {
   integer,
   Position,
   Range,
-} from 'vscode-languageserver';
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import { parseAllDocuments } from 'yaml';
-import { IAnsibleLintConfig } from '../interfaces/ansibleLintConfig';
-import { fileExists, hasOwnProperty } from '../utils/misc';
-import { WorkspaceFolderContext } from './workspaceManager';
-import { CommandRunner } from '../utils/commandRunner';
+} from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { parseAllDocuments } from "yaml";
+import { IAnsibleLintConfig } from "../interfaces/ansibleLintConfig";
+import { fileExists, hasOwnProperty } from "../utils/misc";
+import { WorkspaceFolderContext } from "./workspaceManager";
+import { CommandRunner } from "../utils/commandRunner";
 
 /**
  * Acts as and interface to ansible-lint and a cache of its output.
@@ -58,11 +58,11 @@ export class AnsibleLint {
 
     if (!settings.ansibleLint.enabled) {
       console.debug(
-        'Ansible-lint is disabled. Falling back to ansible syntax-check'
+        "Ansible-lint is disabled. Falling back to ansible syntax-check"
       );
       return;
     } else {
-      let linterArguments = settings.ansibleLint.arguments ?? '';
+      let linterArguments = settings.ansibleLint.arguments ?? "";
 
       // Determine linter config file
       let ansibleLintConfigPath = linterArguments.match(
@@ -97,7 +97,7 @@ export class AnsibleLint {
         ansibleLintConfigPath
       );
 
-      progressTracker.begin('ansible-lint', undefined, 'Processing files...');
+      progressTracker.begin("ansible-lint", undefined, "Processing files...");
 
       const commandRunner = new CommandRunner(
         this.connection,
@@ -108,7 +108,7 @@ export class AnsibleLint {
       try {
         // get Ansible configuration
         const result = await commandRunner.runCommand(
-          'ansible-lint',
+          "ansible-lint",
           `${linterArguments} "${docPath}"`,
           workingDirectory,
           mountPaths
@@ -173,7 +173,7 @@ export class AnsibleLint {
     const diagnostics: Map<string, Diagnostic[]> = new Map();
     if (!result) {
       this.connection.console.warn(
-        'Standard output from ansible-lint is suspiciously empty.'
+        "Standard output from ansible-lint is suspiciously empty."
       );
       return diagnostics;
     }
@@ -182,12 +182,12 @@ export class AnsibleLint {
       if (report instanceof Array) {
         for (const item of report) {
           if (
-            typeof item.check_name === 'string' &&
+            typeof item.check_name === "string" &&
             item.location &&
-            typeof item.location.path === 'string' &&
+            typeof item.location.path === "string" &&
             item.location.lines &&
             (item.location.lines.begin ||
-              typeof item.location.lines.begin === 'number')
+              typeof item.location.lines.begin === "number")
           ) {
             const begin_line =
               item.location.lines.begin.line || item.location.lines.begin || 1;
@@ -241,15 +241,15 @@ export class AnsibleLint {
               message: message,
               range: range || Range.create(0, 0, 0, 0),
               severity: severity,
-              source: 'Ansible',
+              source: "Ansible",
             });
           }
         }
       }
     } catch (error) {
       this.connection.window.showErrorMessage(
-        'Could not parse ansible-lint output. Please check your ansible-lint installation & configuration.' +
-          ' More info in `Ansible Server` output.'
+        "Could not parse ansible-lint output. Please check your ansible-lint installation & configuration." +
+          " More info in `Ansible Server` output."
       );
       let message: string;
       if (error instanceof Error) {
@@ -297,16 +297,16 @@ export class AnsibleLint {
     };
     try {
       const configContents = await fs.readFile(configPath, {
-        encoding: 'utf8',
+        encoding: "utf8",
       });
       parseAllDocuments(configContents).forEach((configDoc) => {
         const configObject: unknown = configDoc.toJSON();
         if (
-          hasOwnProperty(configObject, 'warn_list') &&
+          hasOwnProperty(configObject, "warn_list") &&
           configObject.warn_list instanceof Array
         ) {
           for (const warn_item of configObject.warn_list) {
-            if (typeof warn_item === 'string') {
+            if (typeof warn_item === "string") {
               config.warnList.add(warn_item);
             }
           }
@@ -323,14 +323,14 @@ export class AnsibleLint {
   ): Promise<string | undefined> {
     // find configuration path
     let configPath;
-    const pathArray = uri.split('/');
+    const pathArray = uri.split("/");
 
     // Find first configuration file going up until workspace root
     for (let index = pathArray.length - 1; index >= 0; index--) {
       const candidatePath = pathArray
         .slice(0, index)
-        .concat('.ansible-lint')
-        .join('/');
+        .concat(".ansible-lint")
+        .join("/");
       if (!candidatePath.startsWith(this.context.workspaceFolder.uri)) {
         // we've gone out of the workspace folder
         break;

--- a/src/services/ansiblePlaybook.ts
+++ b/src/services/ansiblePlaybook.ts
@@ -1,6 +1,6 @@
-import * as child_process from 'child_process';
-import * as path from 'path';
-import { URI } from 'vscode-uri';
+import * as child_process from "child_process";
+import * as path from "path";
+import { URI } from "vscode-uri";
 import {
   Connection,
   Diagnostic,
@@ -8,10 +8,10 @@ import {
   integer,
   Position,
   Range,
-} from 'vscode-languageserver';
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import { WorkspaceFolderContext } from './workspaceManager';
-import { CommandRunner } from '../utils/commandRunner';
+} from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { WorkspaceFolderContext } from "./workspaceManager";
+import { CommandRunner } from "../utils/commandRunner";
 
 /**
  * Acts as an interface to ansible-playbook command.
@@ -57,9 +57,9 @@ export class AnsiblePlaybook {
     const settings = await this.context.documentSettings.get(textDocument.uri);
 
     progressTracker.begin(
-      'ansible syntax-check',
+      "ansible syntax-check",
       undefined,
-      'Processing files...'
+      "Processing files..."
     );
 
     const commandRunner = new CommandRunner(
@@ -70,7 +70,7 @@ export class AnsiblePlaybook {
     try {
       // run ansible playbook syntax-check
       await commandRunner.runCommand(
-        'ansible-playbook',
+        "ansible-playbook",
         `${docPath} --syntax-check`,
         workingDirectory,
         mountPaths
@@ -125,7 +125,7 @@ export class AnsiblePlaybook {
     const diagnostics: Map<string, Diagnostic[]> = new Map();
     if (!result) {
       this.connection.console.warn(
-        'Standard output from ansible syntax-check is suspiciously empty.'
+        "Standard output from ansible syntax-check is suspiciously empty."
       );
       return diagnostics;
     }
@@ -152,7 +152,7 @@ export class AnsiblePlaybook {
       message: result,
       range,
       severity,
-      source: 'Ansible',
+      source: "Ansible",
     });
 
     diagnostics.set(locationUri, fileDiagnostics);

--- a/src/services/docsLibrary.ts
+++ b/src/services/docsLibrary.ts
@@ -1,18 +1,18 @@
-import { Connection } from 'vscode-languageserver';
-import { Node } from 'yaml/types';
-import { getDeclaredCollections } from '../utils/yaml';
-import { findDocumentation, findPluginRouting } from '../utils/docsFinder';
-import { WorkspaceFolderContext } from './workspaceManager';
+import { Connection } from "vscode-languageserver";
+import { Node } from "yaml/types";
+import { getDeclaredCollections } from "../utils/yaml";
+import { findDocumentation, findPluginRouting } from "../utils/docsFinder";
+import { WorkspaceFolderContext } from "./workspaceManager";
 import {
   IPluginRoute,
   IPluginRoutesByType,
   IPluginRoutingByCollection,
-} from '../interfaces/pluginRouting';
+} from "../interfaces/pluginRouting";
 import {
   processDocumentationFragments,
   processRawDocumentation,
-} from '../utils/docsParser';
-import { IModuleMetadata } from '../interfaces/module';
+} from "../utils/docsParser";
+import { IModuleMetadata } from "../interfaces/module";
 export class DocsLibrary {
   private connection: Connection;
   private modules = new Map<string, IModuleMetadata>();
@@ -40,12 +40,12 @@ export class DocsLibrary {
         await this.context.executionEnvironment;
       }
       for (const modulesPath of ansibleConfig.module_locations) {
-        (await findDocumentation(modulesPath, 'builtin')).forEach((doc) => {
+        (await findDocumentation(modulesPath, "builtin")).forEach((doc) => {
           this.modules.set(doc.fqcn, doc);
           this.moduleFqcns.add(doc.fqcn);
         });
 
-        (await findDocumentation(modulesPath, 'builtin_doc_fragment')).forEach(
+        (await findDocumentation(modulesPath, "builtin_doc_fragment")).forEach(
           (doc) => {
             this.docFragments.set(doc.fqcn, doc);
           }
@@ -53,11 +53,11 @@ export class DocsLibrary {
       }
 
       (
-        await findPluginRouting(ansibleConfig.ansible_location, 'builtin')
+        await findPluginRouting(ansibleConfig.ansible_location, "builtin")
       ).forEach((r, collection) => this.pluginRouting.set(collection, r));
 
       for (const collectionsPath of ansibleConfig.collections_paths) {
-        (await findDocumentation(collectionsPath, 'collection')).forEach(
+        (await findDocumentation(collectionsPath, "collection")).forEach(
           (doc) => {
             this.modules.set(doc.fqcn, doc);
             this.moduleFqcns.add(doc.fqcn);
@@ -65,18 +65,18 @@ export class DocsLibrary {
         );
 
         (
-          await findDocumentation(collectionsPath, 'collection_doc_fragment')
+          await findDocumentation(collectionsPath, "collection_doc_fragment")
         ).forEach((doc) => {
           this.docFragments.set(doc.fqcn, doc);
         });
 
-        (await findPluginRouting(collectionsPath, 'collection')).forEach(
+        (await findPluginRouting(collectionsPath, "collection")).forEach(
           (r, collection) => this.pluginRouting.set(collection, r)
         );
 
         // add all valid redirect routes as possible FQCNs
         for (const [collection, routesByType] of this.pluginRouting) {
-          for (const [name, route] of routesByType.get('modules') || []) {
+          for (const [name, route] of routesByType.get("modules") || []) {
             if (route.redirect && !route.tombstone) {
               this.moduleFqcns.add(`${collection}.${name}`);
             }
@@ -163,7 +163,7 @@ export class DocsLibrary {
     contextPath: Node[] | undefined
   ) {
     const candidateFqcns = [];
-    if (searchText.split('.').length === 3) {
+    if (searchText.split(".").length === 3) {
       candidateFqcns.push(searchText); // try searching as-is (FQCN match)
     } else {
       candidateFqcns.push(`ansible.builtin.${searchText}`); // try searching built-in
@@ -190,12 +190,12 @@ export class DocsLibrary {
   }
 
   public getModuleRoute(fqcn: string): IPluginRoute | undefined {
-    const fqcn_array = fqcn.split('.');
+    const fqcn_array = fqcn.split(".");
     if (fqcn_array.length === 3) {
       const [namespace, collection, name] = fqcn_array;
       return this.pluginRouting
         .get(`${namespace}.${collection}`)
-        ?.get('modules')
+        ?.get("modules")
         ?.get(name);
     }
   }

--- a/src/services/executionEnvironment.ts
+++ b/src/services/executionEnvironment.ts
@@ -1,19 +1,19 @@
-import * as child_process from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
-import { URI } from 'vscode-uri';
-import { Connection } from 'vscode-languageserver';
-import { v4 as uuidv4 } from 'uuid';
-import { ImagePuller } from '../utils/imagePuller';
-import { asyncExec } from '../utils/misc';
-import { WorkspaceFolderContext } from './workspaceManager';
-import { IContainerEngine } from '../interfaces/extensionSettings';
+import * as child_process from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import { URI } from "vscode-uri";
+import { Connection } from "vscode-languageserver";
+import { v4 as uuidv4 } from "uuid";
+import { ImagePuller } from "../utils/imagePuller";
+import { asyncExec } from "../utils/misc";
+import { WorkspaceFolderContext } from "./workspaceManager";
+import { IContainerEngine } from "../interfaces/extensionSettings";
 
 export class ExecutionEnvironment {
   private connection: Connection;
   private context: WorkspaceFolderContext;
   private useProgressTracker = false;
-  private successFileMarker = 'SUCCESS';
+  private successFileMarker = "SUCCESS";
   private _container_engine: IContainerEngine;
   private _container_image: string;
   private _container_image_id: string;
@@ -35,11 +35,11 @@ export class ExecutionEnvironment {
       }
       this._container_image = settings.executionEnvironment.image;
       this._container_engine = settings.executionEnvironment.containerEngine;
-      if (this._container_engine === 'auto') {
-        for (const ce of ['podman', 'docker']) {
+      if (this._container_engine === "auto") {
+        for (const ce of ["podman", "docker"]) {
           try {
             child_process.execSync(`which ${ce}`, {
-              encoding: 'utf-8',
+              encoding: "utf-8",
             });
           } catch (error) {
             this.connection.console.info(`Container engine '${ce}' not found`);
@@ -52,7 +52,7 @@ export class ExecutionEnvironment {
       } else {
         try {
           child_process.execSync(`which ${this._container_engine}`, {
-            encoding: 'utf-8',
+            encoding: "utf-8",
           });
         } catch (error) {
           this.connection.window.showErrorMessage(
@@ -61,9 +61,9 @@ export class ExecutionEnvironment {
           return;
         }
       }
-      if (!['podman', 'docker'].includes(this._container_engine)) {
+      if (!["podman", "docker"].includes(this._container_engine)) {
         this.connection.window.showInformationMessage(
-          'No valid container engine found.'
+          "No valid container engine found."
         );
         return;
       }
@@ -98,7 +98,7 @@ export class ExecutionEnvironment {
     const ansibleConfig = await this.context.ansibleConfig;
     const containerName = `${this._container_image.replace(
       /[^a-z0-9]/gi,
-      '_'
+      "_"
     )}`;
     let progressTracker;
 
@@ -107,7 +107,7 @@ export class ExecutionEnvironment {
       this.connection.console.log(containerImageIdCommand);
       this._container_image_id = child_process
         .execSync(containerImageIdCommand, {
-          encoding: 'utf-8',
+          encoding: "utf-8",
         })
         .trim();
       const hostCacheBasePath = path.resolve(
@@ -135,7 +135,7 @@ export class ExecutionEnvironment {
         }
         if (progressTracker) {
           progressTracker.begin(
-            'execution-environment',
+            "execution-environment",
             undefined,
             `Copy plugin docs from '${this._container_image} to host cache path`,
             true
@@ -145,18 +145,18 @@ export class ExecutionEnvironment {
           hostCacheBasePath,
           containerName,
           ansibleConfig.collections_paths,
-          'ansible_collections'
+          "ansible_collections"
         );
 
         const builtin_plugin_locations: string[] = [];
         ansibleConfig.module_locations.forEach((modulePath) => {
           const pluginsPathParts = modulePath.split(path.sep).slice(0, -1);
-          if (pluginsPathParts.includes('site-packages')) {
+          if (pluginsPathParts.includes("site-packages")) {
             // ansible-config returns default builtin configured module path
             // as ``<python-path>/site-packages/ansible/modules`` to copy other plugins
             // to local cache strip the ``modules`` part from the path and append
             // ``plugins`` folder.
-            pluginsPathParts.push('plugins');
+            pluginsPathParts.push("plugins");
           }
           builtin_plugin_locations.push(pluginsPathParts.join(path.sep));
         });
@@ -165,7 +165,7 @@ export class ExecutionEnvironment {
           hostCacheBasePath,
           containerName,
           builtin_plugin_locations,
-          '/'
+          "/"
         );
 
         // Copy builtin modules
@@ -173,12 +173,12 @@ export class ExecutionEnvironment {
           hostCacheBasePath,
           containerName,
           ansibleConfig.module_locations,
-          '/'
+          "/"
         );
       }
       // plugin cache successfully created
       fs.closeSync(
-        fs.openSync(path.join(hostCacheBasePath, this.successFileMarker), 'w')
+        fs.openSync(path.join(hostCacheBasePath, this.successFileMarker), "w")
       );
     } catch (error) {
       this.connection.window.showErrorMessage(
@@ -199,11 +199,11 @@ export class ExecutionEnvironment {
       this.context.workspaceFolder.uri
     ).path;
     const containerCommand: Array<string> = [this._container_engine];
-    containerCommand.push(...['run', '--rm']);
-    containerCommand.push(...['--workdir', workspaceFolderPath]);
+    containerCommand.push(...["run", "--rm"]);
+    containerCommand.push(...["--workdir", workspaceFolderPath]);
 
     containerCommand.push(
-      ...['-v', `${workspaceFolderPath}:${workspaceFolderPath}`]
+      ...["-v", `${workspaceFolderPath}:${workspaceFolderPath}`]
     );
 
     for (const mountPath of mountPaths || []) {
@@ -211,23 +211,23 @@ export class ExecutionEnvironment {
       if (containerCommand.includes(volumeMountPath)) {
         continue;
       }
-      containerCommand.push('-v', volumeMountPath);
+      containerCommand.push("-v", volumeMountPath);
     }
 
-    if (this._container_engine === 'podman') {
+    if (this._container_engine === "podman") {
       // container namespace stuff
-      containerCommand.push('--group-add=root');
-      containerCommand.push('--ipc=host');
+      containerCommand.push("--group-add=root");
+      containerCommand.push("--ipc=host");
 
       // docker does not support this option
-      containerCommand.push('--quiet');
+      containerCommand.push("--quiet");
     } else {
       containerCommand.push(`--user=${process.getuid()}`);
     }
     containerCommand.push(`--name ansible_language_server_${uuidv4()}`);
     containerCommand.push(this._container_image);
     containerCommand.push(command);
-    const generatedCommand = containerCommand.join(' ');
+    const generatedCommand = containerCommand.join(" ");
     this.connection.console.log(
       `container engine invocation: ${generatedCommand}`
     );
@@ -282,10 +282,10 @@ export class ExecutionEnvironment {
       this.connection.console.info(`Executing command ${command}`);
       const result = child_process
         .execSync(command, {
-          encoding: 'utf-8',
+          encoding: "utf-8",
         })
         .trim();
-      return result.trim() !== '';
+      return result.trim() !== "";
     } catch (error) {
       this.connection.console.error(error);
       return false;
@@ -299,7 +299,7 @@ export class ExecutionEnvironment {
       const command = `${this._container_engine} run --rm -it -d --name ${containerName} ${this._container_image} bash`;
       this.connection.console.log(`run container with command '${command}'`);
       child_process.execSync(command, {
-        encoding: 'utf-8',
+        encoding: "utf-8",
       });
     } catch (error) {
       this.connection.window.showErrorMessage(
@@ -324,7 +324,7 @@ export class ExecutionEnvironment {
         updatedHostDocPath.push(destPath);
       } else {
         if (
-          srcPath === '' ||
+          srcPath === "" ||
           !this.isPluginInPath(containerName, srcPath, searchKind)
         ) {
           return;
@@ -339,7 +339,7 @@ export class ExecutionEnvironment {
           `Copying plugins from container to local cache path ${copyCommand}`
         );
         asyncExec(copyCommand, {
-          encoding: 'utf-8',
+          encoding: "utf-8",
         });
 
         updatedHostDocPath.push(destPath);

--- a/src/services/metadataLibrary.ts
+++ b/src/services/metadataLibrary.ts
@@ -1,10 +1,10 @@
-import { promises as fs } from 'fs';
-import { Connection } from 'vscode-languageserver';
-import { DidChangeWatchedFilesParams } from 'vscode-languageserver-protocol';
-import { URI } from 'vscode-uri';
-import { parseAllDocuments } from 'yaml';
-import { IDocumentMetadata } from '../interfaces/documentMeta';
-import { fileExists, hasOwnProperty } from '../utils/misc';
+import { promises as fs } from "fs";
+import { Connection } from "vscode-languageserver";
+import { DidChangeWatchedFilesParams } from "vscode-languageserver-protocol";
+import { URI } from "vscode-uri";
+import { parseAllDocuments } from "yaml";
+import { IDocumentMetadata } from "../interfaces/documentMeta";
+import { fileExists, hasOwnProperty } from "../utils/misc";
 export class MetadataLibrary {
   private connection: Connection;
 
@@ -43,15 +43,15 @@ export class MetadataLibrary {
    */
   private getAnsibleMetadataUri(uri: string): string | undefined {
     let metaPath;
-    const pathArray = uri.split('/');
+    const pathArray = uri.split("/");
 
     // Find first
     for (let index = pathArray.length - 1; index >= 0; index--) {
-      if (pathArray[index] === 'tasks') {
+      if (pathArray[index] === "tasks") {
         metaPath = pathArray
           .slice(0, index)
-          .concat('meta', 'main.yml')
-          .join('/');
+          .concat("meta", "main.yml")
+          .join("/");
       }
     }
     return metaPath;
@@ -68,16 +68,16 @@ export class MetadataLibrary {
     if (await fileExists(metadataFilePath)) {
       try {
         const metaContents = await fs.readFile(metadataFilePath, {
-          encoding: 'utf8',
+          encoding: "utf8",
         });
         parseAllDocuments(metaContents).forEach((metaDoc) => {
           const metaObject: unknown = metaDoc.toJSON();
           if (
-            hasOwnProperty(metaObject, 'collections') &&
+            hasOwnProperty(metaObject, "collections") &&
             metaObject.collections instanceof Array
           ) {
             metaObject.collections.forEach((collection) => {
-              if (typeof collection === 'string') {
+              if (typeof collection === "string") {
                 metadata.collections.push(collection);
               }
             });

--- a/src/services/settingsManager.ts
+++ b/src/services/settingsManager.ts
@@ -1,7 +1,7 @@
-import * as _ from 'lodash';
-import { Connection } from 'vscode-languageserver';
-import { DidChangeConfigurationParams } from 'vscode-languageserver-protocol';
-import { ExtensionSettings } from '../interfaces/extensionSettings';
+import * as _ from "lodash";
+import { Connection } from "vscode-languageserver";
+import { DidChangeConfigurationParams } from "vscode-languageserver-protocol";
+import { ExtensionSettings } from "../interfaces/extensionSettings";
 
 export class SettingsManager {
   private connection: Connection;
@@ -13,14 +13,14 @@ export class SettingsManager {
     new Map();
 
   private defaultSettings: ExtensionSettings = {
-    ansible: { path: 'ansible', useFullyQualifiedCollectionNames: true },
-    ansibleLint: { enabled: true, path: 'ansible-lint', arguments: '' },
-    python: { interpreterPath: '', activationScript: '' },
+    ansible: { path: "ansible", useFullyQualifiedCollectionNames: true },
+    ansibleLint: { enabled: true, path: "ansible-lint", arguments: "" },
+    python: { interpreterPath: "", activationScript: "" },
     executionEnvironment: {
-      containerEngine: 'auto',
+      containerEngine: "auto",
       enabled: false,
-      image: 'quay.io/ansible/creator-ee:latest',
-      pullPolicy: 'missing',
+      image: "quay.io/ansible/creator-ee:latest",
+      pullPolicy: "missing",
     },
   };
   private globalSettings: ExtensionSettings = this.defaultSettings;
@@ -48,7 +48,7 @@ export class SettingsManager {
     if (!result) {
       result = this.connection.workspace.getConfiguration({
         scopeUri: uri,
-        section: 'ansible',
+        section: "ansible",
       });
       this.documentSettings.set(uri, result);
     }
@@ -78,7 +78,7 @@ export class SettingsManager {
 
           const newConfigPromise = this.connection.workspace.getConfiguration({
             scopeUri: uri,
-            section: 'ansible',
+            section: "ansible",
           });
           newDocumentSettings.set(uri, newConfigPromise);
 

--- a/src/services/validationManager.ts
+++ b/src/services/validationManager.ts
@@ -1,12 +1,12 @@
-import IntervalTree from '@flatten-js/interval-tree';
+import IntervalTree from "@flatten-js/interval-tree";
 import {
   Connection,
   Diagnostic,
   integer,
   TextDocumentContentChangeEvent,
   TextDocuments,
-} from 'vscode-languageserver';
-import { TextDocument } from 'vscode-languageserver-textdocument';
+} from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
 
 /**
  * Provides cache for selected diagnostics.
@@ -115,7 +115,7 @@ export class ValidationManager {
     const diagnosticTree = this.validationCache.get(fileUri);
     if (diagnosticTree) {
       for (const change of changes) {
-        if ('range' in change) {
+        if ("range" in change) {
           const invalidatedDiagnostics = diagnosticTree.search([
             change.range.start.line,
             change.range.end.line,

--- a/src/services/workspaceManager.ts
+++ b/src/services/workspaceManager.ts
@@ -1,20 +1,20 @@
-import * as _ from 'lodash';
+import * as _ from "lodash";
 import {
   ClientCapabilities,
   Connection,
   DidChangeWatchedFilesParams,
   WorkspaceFolder,
   WorkspaceFoldersChangeEvent,
-} from 'vscode-languageserver';
-import { AnsibleConfig } from './ansibleConfig';
-import { AnsibleLint } from './ansibleLint';
-import { AnsiblePlaybook } from './ansiblePlaybook';
-import { DocsLibrary } from './docsLibrary';
-import { ExecutionEnvironment } from './executionEnvironment';
-import { MetadataLibrary } from './metadataLibrary';
-import { SettingsManager } from './settingsManager';
-import * as path from 'path';
-import { URI } from 'vscode-uri';
+} from "vscode-languageserver";
+import { AnsibleConfig } from "./ansibleConfig";
+import { AnsibleLint } from "./ansibleLint";
+import { AnsiblePlaybook } from "./ansiblePlaybook";
+import { DocsLibrary } from "./docsLibrary";
+import { ExecutionEnvironment } from "./executionEnvironment";
+import { MetadataLibrary } from "./metadataLibrary";
+import { SettingsManager } from "./settingsManager";
+import * as path from "path";
+import { URI } from "vscode-uri";
 
 /**
  * Holds the overall context for the whole workspace.

--- a/src/utils/ansible.ts
+++ b/src/utils/ansible.ts
@@ -1,43 +1,43 @@
-import { MarkupContent, MarkupKind } from 'vscode-languageserver';
+import { MarkupContent, MarkupKind } from "vscode-languageserver";
 export const playKeywords = new Map<string, string | MarkupContent>();
 playKeywords.set(
-  'any_errors_fatal',
-  'Force any un-handled task errors on any host to propagate to all hosts and end the play.'
+  "any_errors_fatal",
+  "Force any un-handled task errors on any host to propagate to all hosts and end the play."
 );
 
 playKeywords.set(
-  'become',
-  'Boolean that controls if privilege escalation is used or not on Task execution. Implemented by the become plugin.'
+  "become",
+  "Boolean that controls if privilege escalation is used or not on Task execution. Implemented by the become plugin."
 );
 
-playKeywords.set('become_exe', {
+playKeywords.set("become_exe", {
   kind: MarkupKind.Markdown,
   value:
-    'Path to the executable used to elevate privileges. Implemented by the become plugin. See `Become Plugins`.',
+    "Path to the executable used to elevate privileges. Implemented by the become plugin. See `Become Plugins`.",
 });
 
 playKeywords.set(
-  'become_flags',
-  'A string of flag(s) to pass to the privilege escalation program when become is True.'
+  "become_flags",
+  "A string of flag(s) to pass to the privilege escalation program when become is True."
 );
 
 playKeywords.set(
-  'become_method',
-  'Which method of privilege escalation to use (such as sudo or su).'
+  "become_method",
+  "Which method of privilege escalation to use (such as sudo or su)."
 );
 
 playKeywords.set(
-  'become_user',
-  'User that you ‘become’ after using privilege escalation. The remote/login user must have permissions to become this user.'
+  "become_user",
+  "User that you ‘become’ after using privilege escalation. The remote/login user must have permissions to become this user."
 );
 
-playKeywords.set('check_mode', {
+playKeywords.set("check_mode", {
   kind: MarkupKind.Markdown,
   value:
-    'A boolean that controls if a task is executed in ‘check’ mode. See `Validating tasks: check mode and diff mode`.',
+    "A boolean that controls if a task is executed in ‘check’ mode. See `Validating tasks: check mode and diff mode`.",
 });
 
-playKeywords.set('collections', {
+playKeywords.set("collections", {
   kind: MarkupKind.Markdown,
   value: `List of collection namespaces to search for modules, plugins, and roles. See \`Using collections in a Playbook\`.
 
@@ -45,198 +45,198 @@ NOTE:
 Tasks within a role do not inherit the value of \`collections\` from the play. To have a role search a list of collections, use the \`collections\` keyword in \`meta/main.yml\` within a role.`,
 });
 
-playKeywords.set('connection', {
+playKeywords.set("connection", {
   kind: MarkupKind.Markdown,
   value:
-    'Allows you to change the connection plugin used for tasks to execute on the target. See `Using connection plugins`.',
+    "Allows you to change the connection plugin used for tasks to execute on the target. See `Using connection plugins`.",
 });
 
-playKeywords.set('debugger', {
+playKeywords.set("debugger", {
   kind: MarkupKind.Markdown,
   value:
-    'Enable debugging tasks based on state of the task result. See `Debugging tasks`.',
+    "Enable debugging tasks based on state of the task result. See `Debugging tasks`.",
 });
 
 playKeywords.set(
-  'diff',
-  'Toggle to make tasks return ‘diff’ information or not.'
+  "diff",
+  "Toggle to make tasks return ‘diff’ information or not."
 );
 
 playKeywords.set(
-  'environment',
-  'A dictionary that gets converted into environment vars to be provided for the task upon execution. This can ONLY be used with modules. This isn’t supported for any other type of plugins nor Ansible itself nor its configuration, it just sets the variables for the code responsible for executing the task. This is not a recommended way to pass in confidential data.'
+  "environment",
+  "A dictionary that gets converted into environment vars to be provided for the task upon execution. This can ONLY be used with modules. This isn’t supported for any other type of plugins nor Ansible itself nor its configuration, it just sets the variables for the code responsible for executing the task. This is not a recommended way to pass in confidential data."
 );
 
 playKeywords.set(
-  'fact_path',
-  'Set the fact path option for the fact gathering plugin controlled by gather_facts.'
+  "fact_path",
+  "Set the fact path option for the fact gathering plugin controlled by gather_facts."
 );
 
 playKeywords.set(
-  'force_handlers',
-  'Will force notified handler execution for hosts even if they failed during the play. Will not trigger if the play itself fails.'
+  "force_handlers",
+  "Will force notified handler execution for hosts even if they failed during the play. Will not trigger if the play itself fails."
 );
 
 playKeywords.set(
-  'gather_facts',
-  'A boolean that controls if the play will automatically run the ‘setup’ task to gather facts for the hosts.'
+  "gather_facts",
+  "A boolean that controls if the play will automatically run the ‘setup’ task to gather facts for the hosts."
 );
 
 playKeywords.set(
-  'gather_subset',
-  'Allows you to pass subset options to the fact gathering plugin controlled by gather_facts.'
+  "gather_subset",
+  "Allows you to pass subset options to the fact gathering plugin controlled by gather_facts."
 );
 
 playKeywords.set(
-  'gather_timeout',
-  'Allows you to set the timeout for the fact gathering plugin controlled by gather_facts.'
+  "gather_timeout",
+  "Allows you to set the timeout for the fact gathering plugin controlled by gather_facts."
 );
 
 playKeywords.set(
-  'handlers',
-  'A section with tasks that are treated as handlers, these won’t get executed normally, only when notified after each section of tasks is complete. A handler’s listen field cannot use templates.'
+  "handlers",
+  "A section with tasks that are treated as handlers, these won’t get executed normally, only when notified after each section of tasks is complete. A handler’s listen field cannot use templates."
 );
 
 playKeywords.set(
-  'hosts',
-  'A list of groups, hosts or host pattern that translates into a list of hosts that are the play’s target.'
+  "hosts",
+  "A list of groups, hosts or host pattern that translates into a list of hosts that are the play’s target."
 );
 
 playKeywords.set(
-  'ignore_errors',
-  'Boolean that allows you to ignore task failures and continue with play. It does not affect connection errors.'
+  "ignore_errors",
+  "Boolean that allows you to ignore task failures and continue with play. It does not affect connection errors."
 );
 
 playKeywords.set(
-  'ignore_unreachable',
-  'Boolean that allows you to ignore task failures due to an unreachable host and continue with the play. This does not affect other task errors (see ignore_errors) but is useful for groups of volatile/ephemeral hosts.'
+  "ignore_unreachable",
+  "Boolean that allows you to ignore task failures due to an unreachable host and continue with the play. This does not affect other task errors (see ignore_errors) but is useful for groups of volatile/ephemeral hosts."
 );
 
 playKeywords.set(
-  'max_fail_percentage',
-  'Can be used to abort the run after a given percentage of hosts in the current batch has failed. This only works on linear or linear derived strategies.'
+  "max_fail_percentage",
+  "Can be used to abort the run after a given percentage of hosts in the current batch has failed. This only works on linear or linear derived strategies."
 );
 
 playKeywords.set(
-  'module_defaults',
-  'Specifies default parameter values for modules.'
+  "module_defaults",
+  "Specifies default parameter values for modules."
 );
 
 playKeywords.set(
-  'name',
-  'Identifier. Can be used for documentation, or in tasks/handlers.'
+  "name",
+  "Identifier. Can be used for documentation, or in tasks/handlers."
 );
 
-playKeywords.set('no_log', 'Boolean that controls information disclosure.');
+playKeywords.set("no_log", "Boolean that controls information disclosure.");
 
 playKeywords.set(
-  'order',
-  'Controls the sorting of hosts as they are used for executing the play. Possible values are inventory (default), sorted, reverse_sorted, reverse_inventory and shuffle.'
-);
-
-playKeywords.set(
-  'port',
-  'Used to override the default port used in a connection.'
+  "order",
+  "Controls the sorting of hosts as they are used for executing the play. Possible values are inventory (default), sorted, reverse_sorted, reverse_inventory and shuffle."
 );
 
 playKeywords.set(
-  'post_tasks',
-  'A list of tasks to execute after the tasks section.'
-);
-
-playKeywords.set('pre_tasks', 'A list of tasks to execute before roles.');
-
-playKeywords.set(
-  'remote_user',
-  'User used to log into the target via the connection plugin.'
-);
-
-playKeywords.set('roles', 'List of roles to be imported into the play');
-
-playKeywords.set(
-  'run_once',
-  'Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterwards apply any results and facts to all active hosts in the same batch.'
+  "port",
+  "Used to override the default port used in a connection."
 );
 
 playKeywords.set(
-  'serial',
-  'Explicitly define how Ansible batches the execution of the current play on the play’s target'
+  "post_tasks",
+  "A list of tasks to execute after the tasks section."
+);
+
+playKeywords.set("pre_tasks", "A list of tasks to execute before roles.");
+
+playKeywords.set(
+  "remote_user",
+  "User used to log into the target via the connection plugin."
+);
+
+playKeywords.set("roles", "List of roles to be imported into the play");
+
+playKeywords.set(
+  "run_once",
+  "Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterwards apply any results and facts to all active hosts in the same batch."
 );
 
 playKeywords.set(
-  'strategy',
-  'Allows you to choose the connection plugin to use for the play.'
+  "serial",
+  "Explicitly define how Ansible batches the execution of the current play on the play’s target"
 );
 
 playKeywords.set(
-  'tags',
-  'Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line.'
+  "strategy",
+  "Allows you to choose the connection plugin to use for the play."
 );
 
 playKeywords.set(
-  'tasks',
-  'Main list of tasks to execute in the play, they run after roles and before post_tasks.'
+  "tags",
+  "Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line."
 );
 
 playKeywords.set(
-  'throttle',
-  'Limit number of concurrent task runs on task, block and playbook level. This is independent of the forks and serial settings, but cannot be set higher than those limits. For example, if forks is set to 10 and the throttle is set to 15, at most 10 hosts will be operated on in parallel.'
+  "tasks",
+  "Main list of tasks to execute in the play, they run after roles and before post_tasks."
 );
 
 playKeywords.set(
-  'timeout',
-  'Time limit for task to execute in, if exceeded Ansible will interrupt and fail the task.'
+  "throttle",
+  "Limit number of concurrent task runs on task, block and playbook level. This is independent of the forks and serial settings, but cannot be set higher than those limits. For example, if forks is set to 10 and the throttle is set to 15, at most 10 hosts will be operated on in parallel."
 );
-
-playKeywords.set('vars', 'Dictionary/map of variables');
 
 playKeywords.set(
-  'vars_files',
-  'List of files that contain vars to include in the play.'
+  "timeout",
+  "Time limit for task to execute in, if exceeded Ansible will interrupt and fail the task."
 );
 
-playKeywords.set('vars_prompt', 'List of variables to prompt for.');
+playKeywords.set("vars", "Dictionary/map of variables");
+
+playKeywords.set(
+  "vars_files",
+  "List of files that contain vars to include in the play."
+);
+
+playKeywords.set("vars_prompt", "List of variables to prompt for.");
 
 export const roleKeywords = new Map<string, string | MarkupContent>();
 roleKeywords.set(
-  'any_errors_fatal',
-  'Force any un-handled task errors on any host to propagate to all hosts and end the play.'
+  "any_errors_fatal",
+  "Force any un-handled task errors on any host to propagate to all hosts and end the play."
 );
 
-roleKeywords.set('become', {
+roleKeywords.set("become", {
   kind: MarkupKind.Markdown,
   value:
-    'Boolean that controls if privilege escalation is used or not on Task execution. Implemented by the become plugin. See `Become Plugins`.',
+    "Boolean that controls if privilege escalation is used or not on Task execution. Implemented by the become plugin. See `Become Plugins`.",
 });
 
-roleKeywords.set('become_exe', {
+roleKeywords.set("become_exe", {
   kind: MarkupKind.Markdown,
   value:
-    'Path to the executable used to elevate privileges. Implemented by the become plugin. See `Become Plugins`.',
+    "Path to the executable used to elevate privileges. Implemented by the become plugin. See `Become Plugins`.",
 });
 
 roleKeywords.set(
-  'become_flags',
-  'A string of flag(s) to pass to the privilege escalation program when become is True.'
+  "become_flags",
+  "A string of flag(s) to pass to the privilege escalation program when become is True."
 );
 
 roleKeywords.set(
-  'become_method',
-  'Which method of privilege escalation to use (such as sudo or su).'
+  "become_method",
+  "Which method of privilege escalation to use (such as sudo or su)."
 );
 
 roleKeywords.set(
-  'become_user',
-  'User that you ‘become’ after using privilege escalation. The remote/login user must have permissions to become this user.'
+  "become_user",
+  "User that you ‘become’ after using privilege escalation. The remote/login user must have permissions to become this user."
 );
 
-roleKeywords.set('check_mode', {
+roleKeywords.set("check_mode", {
   kind: MarkupKind.Markdown,
   value:
-    'A boolean that controls if a task is executed in ‘check’ mode. See `Validating tasks: check mode and diff mode`.',
+    "A boolean that controls if a task is executed in ‘check’ mode. See `Validating tasks: check mode and diff mode`.",
 });
 
-roleKeywords.set('collections', {
+roleKeywords.set("collections", {
   kind: MarkupKind.Markdown,
   value: `List of collection namespaces to search for modules, plugins, and roles. See \`Using collections in a Playbook\`.
 
@@ -244,144 +244,144 @@ NOTE:
 Tasks within a role do not inherit the value of \`collections\` from the play. To have a role search a list of collections, use the \`collections\` keyword in \`meta/main.yml\` within a role.`,
 });
 
-roleKeywords.set('connection', {
+roleKeywords.set("connection", {
   kind: MarkupKind.Markdown,
   value:
-    'Allows you to change the connection plugin used for tasks to execute on the target. See `Using connection plugins`.',
+    "Allows you to change the connection plugin used for tasks to execute on the target. See `Using connection plugins`.",
 });
 
-roleKeywords.set('debugger', {
+roleKeywords.set("debugger", {
   kind: MarkupKind.Markdown,
   value:
-    'Enable debugging tasks based on state of the task result. See `Debugging tasks`.',
+    "Enable debugging tasks based on state of the task result. See `Debugging tasks`.",
 });
 
 roleKeywords.set(
-  'delegate_facts',
-  'Boolean that allows you to apply facts to a delegated host instead of inventory_hostname.'
+  "delegate_facts",
+  "Boolean that allows you to apply facts to a delegated host instead of inventory_hostname."
 );
 
 roleKeywords.set(
-  'delegate_to',
-  'Host to execute task instead of the target (inventory_hostname). Connection vars from the delegated host will also be used for the task.'
+  "delegate_to",
+  "Host to execute task instead of the target (inventory_hostname). Connection vars from the delegated host will also be used for the task."
 );
 
 roleKeywords.set(
-  'diff',
-  'Toggle to make tasks return ‘diff’ information or not.'
+  "diff",
+  "Toggle to make tasks return ‘diff’ information or not."
 );
 
 roleKeywords.set(
-  'environment',
-  'A dictionary that gets converted into environment vars to be provided for the task upon execution. This can ONLY be used with modules. This isn’t supported for any other type of plugins nor Ansible itself nor its configuration, it just sets the variables for the code responsible for executing the task. This is not a recommended way to pass in confidential data.'
+  "environment",
+  "A dictionary that gets converted into environment vars to be provided for the task upon execution. This can ONLY be used with modules. This isn’t supported for any other type of plugins nor Ansible itself nor its configuration, it just sets the variables for the code responsible for executing the task. This is not a recommended way to pass in confidential data."
 );
 
 roleKeywords.set(
-  'ignore_errors',
-  'Boolean that allows you to ignore task failures and continue with play. It does not affect connection errors.'
+  "ignore_errors",
+  "Boolean that allows you to ignore task failures and continue with play. It does not affect connection errors."
 );
 
 roleKeywords.set(
-  'ignore_unreachable',
-  'Boolean that allows you to ignore task failures due to an unreachable host and continue with the play. This does not affect other task errors (see ignore_errors) but is useful for groups of volatile/ephemeral hosts.'
+  "ignore_unreachable",
+  "Boolean that allows you to ignore task failures due to an unreachable host and continue with the play. This does not affect other task errors (see ignore_errors) but is useful for groups of volatile/ephemeral hosts."
 );
 
 roleKeywords.set(
-  'module_defaults',
-  'Specifies default parameter values for modules.'
+  "module_defaults",
+  "Specifies default parameter values for modules."
 );
 
 roleKeywords.set(
-  'name',
-  'Identifier. Can be used for documentation, or in tasks/handlers.'
+  "name",
+  "Identifier. Can be used for documentation, or in tasks/handlers."
 );
 
-roleKeywords.set('no_log', 'Boolean that controls information disclosure.');
+roleKeywords.set("no_log", "Boolean that controls information disclosure.");
 
 roleKeywords.set(
-  'port',
-  'Used to override the default port used in a connection.'
-);
-
-roleKeywords.set(
-  'remote_user',
-  'User used to log into the target via the connection plugin.'
+  "port",
+  "Used to override the default port used in a connection."
 );
 
 roleKeywords.set(
-  'run_once',
-  'Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterwards apply any results and facts to all active hosts in the same batch.'
+  "remote_user",
+  "User used to log into the target via the connection plugin."
 );
 
 roleKeywords.set(
-  'tags',
-  'Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line.'
+  "run_once",
+  "Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterwards apply any results and facts to all active hosts in the same batch."
 );
 
 roleKeywords.set(
-  'throttle',
-  'Limit number of concurrent task runs on task, block and playbook level. This is independent of the forks and serial settings, but cannot be set higher than those limits. For example, if forks is set to 10 and the throttle is set to 15, at most 10 hosts will be operated on in parallel.'
+  "tags",
+  "Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line."
 );
 
 roleKeywords.set(
-  'timeout',
-  'Time limit for task to execute in, if exceeded Ansible will interrupt and fail the task.'
+  "throttle",
+  "Limit number of concurrent task runs on task, block and playbook level. This is independent of the forks and serial settings, but cannot be set higher than those limits. For example, if forks is set to 10 and the throttle is set to 15, at most 10 hosts will be operated on in parallel."
 );
 
-roleKeywords.set('vars', 'Dictionary/map of variables');
+roleKeywords.set(
+  "timeout",
+  "Time limit for task to execute in, if exceeded Ansible will interrupt and fail the task."
+);
+
+roleKeywords.set("vars", "Dictionary/map of variables");
 
 roleKeywords.set(
-  'when',
-  'Conditional expression, determines if an iteration of a task is run or not.'
+  "when",
+  "Conditional expression, determines if an iteration of a task is run or not."
 );
 
 export const blockKeywords = new Map<string, string | MarkupContent>();
 blockKeywords.set(
-  'always',
-  'List of tasks, in a block, that execute no matter if there is an error in the block or not.'
+  "always",
+  "List of tasks, in a block, that execute no matter if there is an error in the block or not."
 );
 
 blockKeywords.set(
-  'any_errors_fatal',
-  'Force any un-handled task errors on any host to propagate to all hosts and end the play.'
+  "any_errors_fatal",
+  "Force any un-handled task errors on any host to propagate to all hosts and end the play."
 );
 
-blockKeywords.set('become', {
+blockKeywords.set("become", {
   kind: MarkupKind.Markdown,
   value:
-    'Boolean that controls if privilege escalation is used or not on Task execution. Implemented by the become plugin. See `Become Plugins`.',
+    "Boolean that controls if privilege escalation is used or not on Task execution. Implemented by the become plugin. See `Become Plugins`.",
 });
 
-blockKeywords.set('become_exe', {
+blockKeywords.set("become_exe", {
   kind: MarkupKind.Markdown,
   value:
-    'Path to the executable used to elevate privileges. Implemented by the become plugin. See `Become Plugins`.',
+    "Path to the executable used to elevate privileges. Implemented by the become plugin. See `Become Plugins`.",
 });
 
 blockKeywords.set(
-  'become_flags',
-  'A string of flag(s) to pass to the privilege escalation program when become is True.'
+  "become_flags",
+  "A string of flag(s) to pass to the privilege escalation program when become is True."
 );
 
 blockKeywords.set(
-  'become_method',
-  'Which method of privilege escalation to use (such as sudo or su).'
+  "become_method",
+  "Which method of privilege escalation to use (such as sudo or su)."
 );
 
 blockKeywords.set(
-  'become_user',
-  'User that you ‘become’ after using privilege escalation. The remote/login user must have permissions to become this user.'
+  "become_user",
+  "User that you ‘become’ after using privilege escalation. The remote/login user must have permissions to become this user."
 );
 
-blockKeywords.set('block', 'List of tasks in a block.');
+blockKeywords.set("block", "List of tasks in a block.");
 
-blockKeywords.set('check_mode', {
+blockKeywords.set("check_mode", {
   kind: MarkupKind.Markdown,
   value:
-    'A boolean that controls if a task is executed in ‘check’ mode. See `Validating tasks: check mode and diff mode`.',
+    "A boolean that controls if a task is executed in ‘check’ mode. See `Validating tasks: check mode and diff mode`.",
 });
 
-blockKeywords.set('collections', {
+blockKeywords.set("collections", {
   kind: MarkupKind.Markdown,
   value: `List of collection namespaces to search for modules, plugins, and roles. See \`Using collections in a Playbook\`.
 
@@ -389,167 +389,167 @@ NOTE:
 Tasks within a role do not inherit the value of \`collections\` from the play. To have a role search a list of collections, use the \`collections\` keyword in \`meta/main.yml\` within a role.`,
 });
 
-blockKeywords.set('connection', {
+blockKeywords.set("connection", {
   kind: MarkupKind.Markdown,
   value:
-    'Allows you to change the connection plugin used for tasks to execute on the target. See `Using connection plugins`.',
+    "Allows you to change the connection plugin used for tasks to execute on the target. See `Using connection plugins`.",
 });
 
-blockKeywords.set('debugger', {
+blockKeywords.set("debugger", {
   kind: MarkupKind.Markdown,
   value:
-    'Enable debugging tasks based on state of the task result. See `Debugging tasks`.',
+    "Enable debugging tasks based on state of the task result. See `Debugging tasks`.",
 });
 
 blockKeywords.set(
-  'delegate_facts',
-  'Boolean that allows you to apply facts to a delegated host instead of inventory_hostname.'
+  "delegate_facts",
+  "Boolean that allows you to apply facts to a delegated host instead of inventory_hostname."
 );
 
 blockKeywords.set(
-  'delegate_to',
-  'Host to execute task instead of the target (inventory_hostname). Connection vars from the delegated host will also be used for the task.'
+  "delegate_to",
+  "Host to execute task instead of the target (inventory_hostname). Connection vars from the delegated host will also be used for the task."
 );
 
 blockKeywords.set(
-  'diff',
-  'Toggle to make tasks return ‘diff’ information or not.'
+  "diff",
+  "Toggle to make tasks return ‘diff’ information or not."
 );
 
 blockKeywords.set(
-  'environment',
-  'A dictionary that gets converted into environment vars to be provided for the task upon execution. This can ONLY be used with modules. This isn’t supported for any other type of plugins nor Ansible itself nor its configuration, it just sets the variables for the code responsible for executing the task. This is not a recommended way to pass in confidential data.'
+  "environment",
+  "A dictionary that gets converted into environment vars to be provided for the task upon execution. This can ONLY be used with modules. This isn’t supported for any other type of plugins nor Ansible itself nor its configuration, it just sets the variables for the code responsible for executing the task. This is not a recommended way to pass in confidential data."
 );
 
 blockKeywords.set(
-  'ignore_errors',
-  'Boolean that allows you to ignore task failures and continue with play. It does not affect connection errors.'
+  "ignore_errors",
+  "Boolean that allows you to ignore task failures and continue with play. It does not affect connection errors."
 );
 
 blockKeywords.set(
-  'ignore_unreachable',
-  'Boolean that allows you to ignore task failures due to an unreachable host and continue with the play. This does not affect other task errors (see ignore_errors) but is useful for groups of volatile/ephemeral hosts.'
+  "ignore_unreachable",
+  "Boolean that allows you to ignore task failures due to an unreachable host and continue with the play. This does not affect other task errors (see ignore_errors) but is useful for groups of volatile/ephemeral hosts."
 );
 
 blockKeywords.set(
-  'module_defaults',
-  'Specifies default parameter values for modules.'
+  "module_defaults",
+  "Specifies default parameter values for modules."
 );
 
 blockKeywords.set(
-  'name',
-  'Identifier. Can be used for documentation, or in tasks/handlers.'
+  "name",
+  "Identifier. Can be used for documentation, or in tasks/handlers."
 );
 
-blockKeywords.set('no_log', 'Boolean that controls information disclosure.');
+blockKeywords.set("no_log", "Boolean that controls information disclosure.");
 
 blockKeywords.set(
-  'notify',
-  'List of handlers to notify when the task returns a ‘changed=True’ status.'
-);
-
-blockKeywords.set(
-  'port',
-  'Used to override the default port used in a connection.'
+  "notify",
+  "List of handlers to notify when the task returns a ‘changed=True’ status."
 );
 
 blockKeywords.set(
-  'remote_user',
-  'User used to log into the target via the connection plugin.'
+  "port",
+  "Used to override the default port used in a connection."
 );
 
 blockKeywords.set(
-  'rescue',
-  'List of tasks in a block that run if there is a task error in the main block list.'
+  "remote_user",
+  "User used to log into the target via the connection plugin."
 );
 
 blockKeywords.set(
-  'run_once',
-  'Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterwards apply any results and facts to all active hosts in the same batch.'
+  "rescue",
+  "List of tasks in a block that run if there is a task error in the main block list."
 );
 
 blockKeywords.set(
-  'tags',
-  'Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line.'
+  "run_once",
+  "Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterwards apply any results and facts to all active hosts in the same batch."
 );
 
 blockKeywords.set(
-  'throttle',
-  'Limit number of concurrent task runs on task, block and playbook level. This is independent of the forks and serial settings, but cannot be set higher than those limits. For example, if forks is set to 10 and the throttle is set to 15, at most 10 hosts will be operated on in parallel.'
+  "tags",
+  "Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line."
 );
 
 blockKeywords.set(
-  'timeout',
-  'Time limit for task to execute in, if exceeded Ansible will interrupt and fail the task.'
+  "throttle",
+  "Limit number of concurrent task runs on task, block and playbook level. This is independent of the forks and serial settings, but cannot be set higher than those limits. For example, if forks is set to 10 and the throttle is set to 15, at most 10 hosts will be operated on in parallel."
 );
 
-blockKeywords.set('vars', 'Dictionary/map of variables');
+blockKeywords.set(
+  "timeout",
+  "Time limit for task to execute in, if exceeded Ansible will interrupt and fail the task."
+);
+
+blockKeywords.set("vars", "Dictionary/map of variables");
 
 blockKeywords.set(
-  'when',
-  'Conditional expression, determines if an iteration of a task is run or not.'
+  "when",
+  "Conditional expression, determines if an iteration of a task is run or not."
 );
 
 export const taskKeywords = new Map<string, string | MarkupContent>();
 taskKeywords.set(
-  'action',
-  'The ‘action’ to execute for a task, it normally translates into a C(module) or action plugin.'
+  "action",
+  "The ‘action’ to execute for a task, it normally translates into a C(module) or action plugin."
 );
 
 taskKeywords.set(
-  'any_errors_fatal',
-  'Force any un-handled task errors on any host to propagate to all hosts and end the play.'
+  "any_errors_fatal",
+  "Force any un-handled task errors on any host to propagate to all hosts and end the play."
 );
 
 taskKeywords.set(
-  'args',
-  'A secondary way to add arguments into a task. Takes a dictionary in which keys map to options and values.'
+  "args",
+  "A secondary way to add arguments into a task. Takes a dictionary in which keys map to options and values."
 );
 
 taskKeywords.set(
-  'async',
-  'Run a task asynchronously if the C(action) supports this; value is maximum runtime in seconds.'
+  "async",
+  "Run a task asynchronously if the C(action) supports this; value is maximum runtime in seconds."
 );
 
-taskKeywords.set('become', {
+taskKeywords.set("become", {
   kind: MarkupKind.Markdown,
   value:
-    'Boolean that controls if privilege escalation is used or not on Task execution. Implemented by the become plugin. See `Become Plugins`.',
+    "Boolean that controls if privilege escalation is used or not on Task execution. Implemented by the become plugin. See `Become Plugins`.",
 });
 
-taskKeywords.set('become_exe', {
+taskKeywords.set("become_exe", {
   kind: MarkupKind.Markdown,
   value:
-    'Path to the executable used to elevate privileges. Implemented by the become plugin. See `Become Plugins`.',
+    "Path to the executable used to elevate privileges. Implemented by the become plugin. See `Become Plugins`.",
 });
 
 taskKeywords.set(
-  'become_flags',
-  'A string of flag(s) to pass to the privilege escalation program when become is True.'
+  "become_flags",
+  "A string of flag(s) to pass to the privilege escalation program when become is True."
 );
 
 taskKeywords.set(
-  'become_method',
-  'Which method of privilege escalation to use (such as sudo or su).'
+  "become_method",
+  "Which method of privilege escalation to use (such as sudo or su)."
 );
 
 taskKeywords.set(
-  'become_user',
-  'User that you ‘become’ after using privilege escalation. The remote/login user must have permissions to become this user.'
+  "become_user",
+  "User that you ‘become’ after using privilege escalation. The remote/login user must have permissions to become this user."
 );
 
 taskKeywords.set(
-  'changed_when',
-  'Conditional expression that overrides the task’s normal ‘changed’ status.'
+  "changed_when",
+  "Conditional expression that overrides the task’s normal ‘changed’ status."
 );
 
-taskKeywords.set('check_mode', {
+taskKeywords.set("check_mode", {
   kind: MarkupKind.Markdown,
   value:
-    'A boolean that controls if a task is executed in ‘check’ mode. See `Validating tasks: check mode and diff mode`.',
+    "A boolean that controls if a task is executed in ‘check’ mode. See `Validating tasks: check mode and diff mode`.",
 });
 
-taskKeywords.set('collections', {
+taskKeywords.set("collections", {
   kind: MarkupKind.Markdown,
   value: `List of collection namespaces to search for modules, plugins, and roles. See \`Using collections in a Playbook\`.
 
@@ -557,145 +557,145 @@ NOTE:
 Tasks within a role do not inherit the value of \`collections\` from the play. To have a role search a list of collections, use the \`collections\` keyword in \`meta/main.yml\` within a role.`,
 });
 
-taskKeywords.set('connection', {
+taskKeywords.set("connection", {
   kind: MarkupKind.Markdown,
   value:
-    'Allows you to change the connection plugin used for tasks to execute on the target. See `Using connection plugins`.',
+    "Allows you to change the connection plugin used for tasks to execute on the target. See `Using connection plugins`.",
 });
 
-taskKeywords.set('debugger', {
+taskKeywords.set("debugger", {
   kind: MarkupKind.Markdown,
   value:
-    'Enable debugging tasks based on state of the task result. See `Debugging tasks`.',
+    "Enable debugging tasks based on state of the task result. See `Debugging tasks`.",
 });
 
 taskKeywords.set(
-  'delay',
-  'Number of seconds to delay between retries. This setting is only used in combination with until.'
+  "delay",
+  "Number of seconds to delay between retries. This setting is only used in combination with until."
 );
 
 taskKeywords.set(
-  'delegate_facts',
-  'Boolean that allows you to apply facts to a delegated host instead of inventory_hostname.'
+  "delegate_facts",
+  "Boolean that allows you to apply facts to a delegated host instead of inventory_hostname."
 );
 
 taskKeywords.set(
-  'delegate_to',
-  'Host to execute task instead of the target (inventory_hostname). Connection vars from the delegated host will also be used for the task.'
+  "delegate_to",
+  "Host to execute task instead of the target (inventory_hostname). Connection vars from the delegated host will also be used for the task."
 );
 
 taskKeywords.set(
-  'diff',
-  'Toggle to make tasks return ‘diff’ information or not.'
+  "diff",
+  "Toggle to make tasks return ‘diff’ information or not."
 );
 
 taskKeywords.set(
-  'environment',
-  'A dictionary that gets converted into environment vars to be provided for the task upon execution. This can ONLY be used with modules. This isn’t supported for any other type of plugins nor Ansible itself nor its configuration, it just sets the variables for the code responsible for executing the task. This is not a recommended way to pass in confidential data.'
+  "environment",
+  "A dictionary that gets converted into environment vars to be provided for the task upon execution. This can ONLY be used with modules. This isn’t supported for any other type of plugins nor Ansible itself nor its configuration, it just sets the variables for the code responsible for executing the task. This is not a recommended way to pass in confidential data."
 );
 
 taskKeywords.set(
-  'failed_when',
-  'Conditional expression that overrides the task’s normal ‘failed’ status.'
+  "failed_when",
+  "Conditional expression that overrides the task’s normal ‘failed’ status."
 );
 
 taskKeywords.set(
-  'ignore_errors',
-  'Boolean that allows you to ignore task failures and continue with play. It does not affect connection errors.'
+  "ignore_errors",
+  "Boolean that allows you to ignore task failures and continue with play. It does not affect connection errors."
 );
 
 taskKeywords.set(
-  'ignore_unreachable',
-  'Boolean that allows you to ignore task failures due to an unreachable host and continue with the play. This does not affect other task errors (see ignore_errors) but is useful for groups of volatile/ephemeral hosts.'
+  "ignore_unreachable",
+  "Boolean that allows you to ignore task failures due to an unreachable host and continue with the play. This does not affect other task errors (see ignore_errors) but is useful for groups of volatile/ephemeral hosts."
 );
 
 taskKeywords.set(
-  'local_action',
-  'Same as action but also implies delegate_to: localhost'
+  "local_action",
+  "Same as action but also implies delegate_to: localhost"
 );
 
 taskKeywords.set(
-  'loop',
-  'Takes a list for the task to iterate over, saving each list element into the item variable (configurable via loop_control)'
+  "loop",
+  "Takes a list for the task to iterate over, saving each list element into the item variable (configurable via loop_control)"
 );
 
 taskKeywords.set(
-  'loop_control',
-  'Several keys here allow you to modify/set loop behavior in a task.'
+  "loop_control",
+  "Several keys here allow you to modify/set loop behavior in a task."
 );
 
 taskKeywords.set(
-  'module_defaults',
-  'Specifies default parameter values for modules.'
+  "module_defaults",
+  "Specifies default parameter values for modules."
 );
 
 taskKeywords.set(
-  'name',
-  'Identifier. Can be used for documentation, or in tasks/handlers.'
+  "name",
+  "Identifier. Can be used for documentation, or in tasks/handlers."
 );
 
-taskKeywords.set('no_log', 'Boolean that controls information disclosure.');
+taskKeywords.set("no_log", "Boolean that controls information disclosure.");
 
 taskKeywords.set(
-  'notify',
-  'List of handlers to notify when the task returns a ‘changed=True’ status.'
-);
-
-taskKeywords.set(
-  'poll',
-  'Sets the polling interval in seconds for async tasks (default 10s).'
+  "notify",
+  "List of handlers to notify when the task returns a ‘changed=True’ status."
 );
 
 taskKeywords.set(
-  'port',
-  'Used to override the default port used in a connection.'
+  "poll",
+  "Sets the polling interval in seconds for async tasks (default 10s)."
 );
 
 taskKeywords.set(
-  'register',
-  'Name of variable that will contain task status and module return data.'
+  "port",
+  "Used to override the default port used in a connection."
 );
 
 taskKeywords.set(
-  'remote_user',
-  'User used to log into the target via the connection plugin.'
+  "register",
+  "Name of variable that will contain task status and module return data."
 );
 
 taskKeywords.set(
-  'retries',
-  'Number of retries before giving up in a until loop. This setting is only used in combination with until.'
+  "remote_user",
+  "User used to log into the target via the connection plugin."
 );
 
 taskKeywords.set(
-  'run_once',
-  'Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterwards apply any results and facts to all active hosts in the same batch.'
+  "retries",
+  "Number of retries before giving up in a until loop. This setting is only used in combination with until."
 );
 
 taskKeywords.set(
-  'tags',
-  'Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line.'
+  "run_once",
+  "Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterwards apply any results and facts to all active hosts in the same batch."
 );
 
 taskKeywords.set(
-  'throttle',
-  'Limit number of concurrent task runs on task, block and playbook level. This is independent of the forks and serial settings, but cannot be set higher than those limits. For example, if forks is set to 10 and the throttle is set to 15, at most 10 hosts will be operated on in parallel.'
+  "tags",
+  "Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line."
 );
 
 taskKeywords.set(
-  'timeout',
-  'Time limit for task to execute in, if exceeded Ansible will interrupt and fail the task.'
+  "throttle",
+  "Limit number of concurrent task runs on task, block and playbook level. This is independent of the forks and serial settings, but cannot be set higher than those limits. For example, if forks is set to 10 and the throttle is set to 15, at most 10 hosts will be operated on in parallel."
 );
 
 taskKeywords.set(
-  'until',
-  'This keyword implies a ‘retries loop’ that will go on until the condition supplied here is met or we hit the retries limit.'
+  "timeout",
+  "Time limit for task to execute in, if exceeded Ansible will interrupt and fail the task."
 );
 
-taskKeywords.set('vars', 'Dictionary/map of variables');
+taskKeywords.set(
+  "until",
+  "This keyword implies a ‘retries loop’ that will go on until the condition supplied here is met or we hit the retries limit."
+);
+
+taskKeywords.set("vars", "Dictionary/map of variables");
 
 taskKeywords.set(
-  'when',
-  'Conditional expression, determines if an iteration of a task is run or not.'
+  "when",
+  "Conditional expression, determines if an iteration of a task is run or not."
 );
 
 export const playExclusiveKeywords = new Map(
@@ -710,5 +710,5 @@ export const playWithoutTaskKeywords = new Map(
 );
 
 export function isTaskKeyword(value: string): boolean {
-  return taskKeywords.has(value) || value.startsWith('with_');
+  return taskKeywords.has(value) || value.startsWith("with_");
 }

--- a/src/utils/commandRunner.ts
+++ b/src/utils/commandRunner.ts
@@ -1,9 +1,9 @@
-import { URI } from 'vscode-uri';
-import { Connection } from 'vscode-languageserver';
-import { withInterpreter, asyncExec } from './misc';
-import { getAnsibleCommandExecPath } from './execPath';
-import { WorkspaceFolderContext } from '../services/workspaceManager';
-import { ExtensionSettings } from '../interfaces/extensionSettings';
+import { URI } from "vscode-uri";
+import { Connection } from "vscode-languageserver";
+import { withInterpreter, asyncExec } from "./misc";
+import { getAnsibleCommandExecPath } from "./execPath";
+import { WorkspaceFolderContext } from "../services/workspaceManager";
+import { ExtensionSettings } from "../interfaces/extensionSettings";
 
 export class CommandRunner {
   private connection: Connection;
@@ -34,9 +34,9 @@ export class CommandRunner {
     let runEnv: NodeJS.ProcessEnv | undefined;
     const isEEEnabled = this.settings.executionEnvironment.enabled;
     const interpreterPath = isEEEnabled
-      ? 'python3'
+      ? "python3"
       : this.settings.python.interpreterPath;
-    if (executable.startsWith('ansible')) {
+    if (executable.startsWith("ansible")) {
       executablePath = isEEEnabled
         ? executable
         : getAnsibleCommandExecPath(executable, this.settings);
@@ -66,7 +66,7 @@ export class CommandRunner {
       ? workingDirectory
       : URI.parse(this.context.workspaceFolder.uri).path;
     const result = await asyncExec(command, {
-      encoding: 'utf-8',
+      encoding: "utf-8",
       cwd: currentWorkingDirectory,
       env: runEnv,
     });
@@ -83,15 +83,15 @@ export class CommandRunner {
     executable: string
   ): Promise<string> | undefined {
     try {
-      const executablePath = await this.runCommand('which', executable);
+      const executablePath = await this.runCommand("which", executable);
       return executablePath.stdout.trim();
     } catch (error) {
       console.log(error);
     }
 
     try {
-      const executablePath = await this.runCommand('whereis', executable);
-      const outParts = executablePath.stdout.split(':');
+      const executablePath = await this.runCommand("whereis", executable);
+      const outParts = executablePath.stdout.split(":");
       return outParts.length >= 2 ? outParts[1].trim() : undefined;
     } catch (error) {
       console.log(error);

--- a/src/utils/docsFinder.ts
+++ b/src/utils/docsFinder.ts
@@ -1,43 +1,43 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { parseDocument } from 'yaml';
-import globby = require('globby');
-import { LazyModuleDocumentation, parseRawRouting } from './docsParser';
-import { IModuleMetadata } from '../interfaces/module';
+import * as fs from "fs";
+import * as path from "path";
+import { parseDocument } from "yaml";
+import globby = require("globby");
+import { LazyModuleDocumentation, parseRawRouting } from "./docsParser";
+import { IModuleMetadata } from "../interfaces/module";
 import {
   IPluginRoutesByType,
   IPluginRoutingByCollection,
-} from '../interfaces/pluginRouting';
+} from "../interfaces/pluginRouting";
 
 export async function findDocumentation(
   dir: string,
   kind:
-    | 'builtin'
-    | 'collection'
-    | 'builtin_doc_fragment'
-    | 'collection_doc_fragment'
+    | "builtin"
+    | "collection"
+    | "builtin_doc_fragment"
+    | "collection_doc_fragment"
 ): Promise<IModuleMetadata[]> {
   if (!fs.existsSync(dir) || fs.lstatSync(dir).isFile()) {
     return [];
   }
   let files;
   switch (kind) {
-    case 'builtin':
-      files = await globby([`${dir}/**/*.py`, '!/**/_*.py']);
+    case "builtin":
+      files = await globby([`${dir}/**/*.py`, "!/**/_*.py"]);
       break;
-    case 'builtin_doc_fragment':
+    case "builtin_doc_fragment":
       files = await globby([
-        `${path.resolve(dir, '../')}/plugins/doc_fragments/*.py`,
-        '!/**/_*.py',
+        `${path.resolve(dir, "../")}/plugins/doc_fragments/*.py`,
+        "!/**/_*.py",
       ]);
       break;
-    case 'collection':
+    case "collection":
       files = await globby([
         `${dir}/ansible_collections/*/*/plugins/modules/*.py`,
         `!${dir}/ansible_collections/*/*/plugins/modules/_*.py`,
       ]);
       break;
-    case 'collection_doc_fragment':
+    case "collection_doc_fragment":
       files = await globby([
         `${dir}/ansible_collections/*/*/plugins/doc_fragments/*.py`,
         `!${dir}/ansible_collections/*/*/plugins/doc_fragments/_*.py`,
@@ -45,17 +45,17 @@ export async function findDocumentation(
       break;
   }
   return files.map((file) => {
-    const name = path.basename(file, '.py');
+    const name = path.basename(file, ".py");
     let namespace;
     let collection;
     switch (kind) {
-      case 'builtin':
-      case 'builtin_doc_fragment':
-        namespace = 'ansible';
-        collection = 'builtin';
+      case "builtin":
+      case "builtin_doc_fragment":
+        namespace = "ansible";
+        collection = "builtin";
         break;
-      case 'collection':
-      case 'collection_doc_fragment':
+      case "collection":
+      case "collection_doc_fragment":
         const pathArray = file.split(path.sep);
         namespace = pathArray[pathArray.length - 5];
         collection = pathArray[pathArray.length - 4];
@@ -74,7 +74,7 @@ export async function findDocumentation(
 
 export async function findPluginRouting(
   dir: string,
-  kind: 'builtin' | 'collection'
+  kind: "builtin" | "collection"
 ): Promise<IPluginRoutingByCollection> {
   const pluginRouting = new Map<string, IPluginRoutesByType>();
   if (!fs.existsSync(dir) || fs.lstatSync(dir).isFile()) {
@@ -82,20 +82,20 @@ export async function findPluginRouting(
   }
   let files;
   switch (kind) {
-    case 'builtin':
+    case "builtin":
       files = await globby([`${dir}/config/ansible_builtin_runtime.yml`]);
       break;
-    case 'collection':
+    case "collection":
       files = await globby([`${dir}/ansible_collections/*/*/meta/runtime.yml`]);
       break;
   }
   for (const file of files) {
     let collection;
     switch (kind) {
-      case 'builtin':
-        collection = 'ansible.builtin';
+      case "builtin":
+        collection = "ansible.builtin";
         break;
-      case 'collection':
+      case "collection":
         const pathArray = file.split(path.sep);
         collection = `${pathArray[pathArray.length - 4]}.${
           pathArray[pathArray.length - 3]
@@ -103,7 +103,7 @@ export async function findPluginRouting(
         break;
     }
     const runtimeContent = await fs.promises.readFile(file, {
-      encoding: 'utf8',
+      encoding: "utf8",
     });
     const document = parseDocument(runtimeContent).toJSON();
     pluginRouting.set(collection, parseRawRouting(document));

--- a/src/utils/docsFormatter.ts
+++ b/src/utils/docsFormatter.ts
@@ -1,11 +1,11 @@
-import { format } from 'util';
-import { MarkupContent, MarkupKind } from 'vscode-languageserver';
+import { format } from "util";
+import { MarkupContent, MarkupKind } from "vscode-languageserver";
 import {
   IDescription,
   IModuleDocumentation,
   IOption,
-} from '../interfaces/module';
-import { IPluginRoute } from '../interfaces/pluginRouting';
+} from "../interfaces/module";
+import { IPluginRoute } from "../interfaces/pluginRouting";
 
 export function formatModule(
   module: IModuleDocumentation,
@@ -13,7 +13,7 @@ export function formatModule(
 ): MarkupContent {
   const sections: string[] = [];
   if (module.deprecated || route?.deprecation) {
-    sections.push('**DEPRECATED**');
+    sections.push("**DEPRECATED**");
     if (route?.deprecation) {
       if (route.deprecation.warningText) {
         sections.push(`${route.deprecation.warningText}`);
@@ -30,27 +30,27 @@ export function formatModule(
     sections.push(`*${formatDescription(module.shortDescription)}*`);
   }
   if (module.description) {
-    sections.push('**Description**');
+    sections.push("**Description**");
     sections.push(formatDescription(module.description));
   }
   if (module.requirements) {
-    sections.push('**Requirements**');
+    sections.push("**Requirements**");
     sections.push(formatDescription(module.requirements));
   }
   if (module.notes) {
-    sections.push('**Notes**');
+    sections.push("**Notes**");
     sections.push(formatDescription(module.notes));
   }
   return {
     kind: MarkupKind.Markdown,
-    value: sections.join('\n\n'),
+    value: sections.join("\n\n"),
   };
 }
 
 export function formatTombstone(route: IPluginRoute): MarkupContent {
   const sections: string[] = [];
   if (route?.tombstone) {
-    sections.push('**REMOVED**');
+    sections.push("**REMOVED**");
     if (route.tombstone.warningText) {
       sections.push(`${route.tombstone.warningText}`);
     }
@@ -63,7 +63,7 @@ export function formatTombstone(route: IPluginRoute): MarkupContent {
   }
   return {
     kind: MarkupKind.Markdown,
-    value: sections.join('\n\n'),
+    value: sections.join("\n\n"),
   };
 }
 
@@ -97,12 +97,12 @@ export function formatOption(
   }
   return {
     kind: MarkupKind.Markdown,
-    value: sections.join('\n\n'),
+    value: sections.join("\n\n"),
   };
 }
 
 export function formatDescription(doc?: IDescription, asList = true): string {
-  let result = '';
+  let result = "";
   if (doc instanceof Array) {
     const lines: string[] = [];
     doc.forEach((element) => {
@@ -112,8 +112,8 @@ export function formatDescription(doc?: IDescription, asList = true): string {
         lines.push(`${replaceMacros(element)}\n`);
       }
     });
-    result += lines.join('\n');
-  } else if (typeof doc === 'string') {
+    result += lines.join("\n");
+  } else if (typeof doc === "string") {
     result += replaceMacros(doc);
   }
   return result;
@@ -122,16 +122,16 @@ export function formatDescription(doc?: IDescription, asList = true): string {
 export function getDetails(option: IOption): string | undefined {
   const details = [];
   if (option.required) {
-    details.push('(required)');
+    details.push("(required)");
   }
   if (option.type) {
-    if (option.type === 'list' && option.elements) {
+    if (option.type === "list" && option.elements) {
       details.push(`list(${option.elements})`);
     } else {
       details.push(option.type);
     }
   }
-  if (details) return details.join(' ');
+  if (details) return details.join(" ");
 }
 
 // TODO: do something with links
@@ -147,18 +147,18 @@ const macroPatterns = {
 };
 function replaceMacros(text: unknown): string {
   let safeText;
-  if (typeof text === 'string') {
+  if (typeof text === "string") {
     safeText = text;
   } else {
     safeText = JSON.stringify(text);
   }
   return safeText
-    .replace(macroPatterns.link, '[$1]($2)')
-    .replace(macroPatterns.url, '$1')
-    .replace(macroPatterns.reference, '[$1]($2)')
-    .replace(macroPatterns.module, '*`$1`*')
-    .replace(macroPatterns.monospace, '`$1`')
-    .replace(macroPatterns.italics, '_$1_')
-    .replace(macroPatterns.bold, '**$1**')
-    .replace(macroPatterns.hr, '<hr>');
+    .replace(macroPatterns.link, "[$1]($2)")
+    .replace(macroPatterns.url, "$1")
+    .replace(macroPatterns.reference, "[$1]($2)")
+    .replace(macroPatterns.module, "*`$1`*")
+    .replace(macroPatterns.monospace, "`$1`")
+    .replace(macroPatterns.italics, "_$1_")
+    .replace(macroPatterns.bold, "**$1**")
+    .replace(macroPatterns.hr, "<hr>");
 }

--- a/src/utils/docsParser.ts
+++ b/src/utils/docsParser.ts
@@ -1,22 +1,22 @@
-import * as _ from 'lodash';
-import * as fs from 'fs';
-import { parseDocument } from 'yaml';
-import { YAMLError } from 'yaml/util';
+import * as _ from "lodash";
+import * as fs from "fs";
+import { parseDocument } from "yaml";
+import { YAMLError } from "yaml/util";
 import {
   IDescription,
   IModuleDocumentation,
   IModuleMetadata,
   IOption,
-} from '../interfaces/module';
-import { hasOwnProperty, isObject } from './misc';
+} from "../interfaces/module";
+import { hasOwnProperty, isObject } from "./misc";
 import {
   IPluginRoute,
   IPluginRoutesByName,
   IPluginRoutesByType,
   IPluginTypes,
-} from '../interfaces/pluginRouting';
+} from "../interfaces/pluginRouting";
 
-const DOCUMENTATION = 'DOCUMENTATION';
+const DOCUMENTATION = "DOCUMENTATION";
 
 export function processDocumentationFragments(
   module: IModuleMetadata,
@@ -27,7 +27,7 @@ export function processDocumentationFragments(
     module.rawDocumentationFragments.get(DOCUMENTATION);
   if (
     mainDocumentationFragment &&
-    hasOwnProperty(mainDocumentationFragment, 'extends_documentation_fragment')
+    hasOwnProperty(mainDocumentationFragment, "extends_documentation_fragment")
   ) {
     const docFragmentNames: string[] =
       mainDocumentationFragment.extends_documentation_fragment instanceof Array
@@ -35,14 +35,14 @@ export function processDocumentationFragments(
         : [mainDocumentationFragment.extends_documentation_fragment];
     const resultContents = {};
     for (const docFragmentName of docFragmentNames) {
-      const fragmentNameArray = docFragmentName.split('.');
+      const fragmentNameArray = docFragmentName.split(".");
       let fragmentPartName: string;
       if (fragmentNameArray.length === 2 || fragmentNameArray.length === 4) {
         fragmentPartName = fragmentNameArray.pop()?.toUpperCase() as string;
       } else {
         fragmentPartName = DOCUMENTATION;
       }
-      const docFragmentCatalogueName = fragmentNameArray.join('.');
+      const docFragmentCatalogueName = fragmentNameArray.join(".");
       const docFragment =
         docFragments.get(docFragmentCatalogueName) ||
         docFragments.get(`ansible.builtin.${docFragmentCatalogueName}`);
@@ -73,7 +73,7 @@ function docFragmentMergeCustomizer(
   key: string
 ): Record<string, unknown>[] | undefined {
   if (
-    ['notes', 'requirements', 'seealso'].includes(key) &&
+    ["notes", "requirements", "seealso"].includes(key) &&
     _.isArray(objValue)
   ) {
     return objValue.concat(srcValue);
@@ -85,7 +85,7 @@ export function processRawDocumentation(
 ): IModuleDocumentation | undefined {
   // currently processing only the main documentation
   const rawDoc = moduleDocParts.get(DOCUMENTATION);
-  if (rawDoc && typeof rawDoc.module === 'string') {
+  if (rawDoc && typeof rawDoc.module === "string") {
     const moduleDoc: IModuleDocumentation = {
       module: rawDoc.module,
       options: processRawOptions(rawDoc.options),
@@ -95,12 +95,12 @@ export function processRawDocumentation(
       moduleDoc.shortDescription = rawDoc.short_description;
     if (isIDescription(rawDoc.description))
       moduleDoc.description = rawDoc.description;
-    if (typeof rawDoc.version_added === 'string')
+    if (typeof rawDoc.version_added === "string")
       moduleDoc.versionAdded = rawDoc.version_added;
     if (isIDescription(rawDoc.author)) moduleDoc.author = rawDoc.author;
     if (isIDescription(rawDoc.requirements))
       moduleDoc.requirements = rawDoc.requirements;
-    if (typeof rawDoc.seealso === 'object')
+    if (typeof rawDoc.seealso === "object")
       moduleDoc.seealso = rawDoc.seealso as Record<string, unknown>;
     if (isIDescription(rawDoc.notes)) moduleDoc.notes = rawDoc.notes;
     return moduleDoc;
@@ -122,12 +122,12 @@ export function processRawOptions(rawOptions: unknown): Map<string, IOption> {
           optionDoc.description = rawOption.description;
         if (rawOption.choices instanceof Array)
           optionDoc.choices = rawOption.choices;
-        if (typeof rawOption.type === 'string') optionDoc.type = rawOption.type;
-        if (typeof rawOption.elements === 'string')
+        if (typeof rawOption.type === "string") optionDoc.type = rawOption.type;
+        if (typeof rawOption.elements === "string")
           optionDoc.elements = rawOption.elements;
         if (rawOption.aliases instanceof Array)
           optionDoc.aliases = rawOption.aliases;
-        if (typeof rawOption.version_added === 'string')
+        if (typeof rawOption.version_added === "string")
           optionDoc.versionAdded = rawOption.version_added;
         options.set(optionName, optionDoc);
         if (optionDoc.aliases) {
@@ -144,20 +144,20 @@ export function processRawOptions(rawOptions: unknown): Map<string, IOption> {
 function isIDescription(obj: unknown): obj is IDescription {
   return (
     obj instanceof Array || // won't check that all elements are string
-    typeof obj === 'string'
+    typeof obj === "string"
   );
 }
 
 export function parseRawRouting(rawDoc: unknown): IPluginRoutesByType {
   const routesByType = new Map<IPluginTypes, IPluginRoutesByName>();
   if (
-    hasOwnProperty(rawDoc, 'plugin_routing') &&
+    hasOwnProperty(rawDoc, "plugin_routing") &&
     isObject(rawDoc.plugin_routing)
   ) {
     for (const [pluginType, rawRoutesByName] of Object.entries(
       rawDoc.plugin_routing
     )) {
-      if (pluginType === 'modules' && isObject(rawRoutesByName)) {
+      if (pluginType === "modules" && isObject(rawRoutesByName)) {
         routesByType.set(pluginType, parseRawRoutesByName(rawRoutesByName));
       }
     }
@@ -184,7 +184,7 @@ function parseRawRoute(rawRoute: Record<PropertyKey, unknown>): IPluginRoute {
   if (isObject(rawRoute.tombstone)) {
     route.tombstone = parseRawDeprecationOrTombstone(rawRoute.tombstone);
   }
-  if (typeof rawRoute.redirect === 'string') {
+  if (typeof rawRoute.redirect === "string") {
     route.redirect = rawRoute.redirect;
   }
   return route;
@@ -200,13 +200,13 @@ function parseRawDeprecationOrTombstone(
   let warningText;
   let removalDate;
   let removalVersion;
-  if (typeof rawInfo.warning_text === 'string') {
+  if (typeof rawInfo.warning_text === "string") {
     warningText = rawInfo.warning_text;
   }
-  if (typeof rawInfo.removal_date === 'string') {
+  if (typeof rawInfo.removal_date === "string") {
     removalDate = rawInfo.removal_date;
   }
-  if (typeof rawInfo.removal_version === 'string') {
+  if (typeof rawInfo.removal_version === "string") {
     removalVersion = rawInfo.removal_version;
   }
   return {
@@ -247,7 +247,7 @@ export class LazyModuleDocumentation implements IModuleMetadata {
   public get rawDocumentationFragments(): Map<string, Record<string, unknown>> {
     if (!this._contents) {
       this._contents = new Map<string, Record<string, unknown>>();
-      const contents = fs.readFileSync(this.source, { encoding: 'utf8' });
+      const contents = fs.readFileSync(this.source, { encoding: "utf8" });
       let m;
       while ((m = LazyModuleDocumentation.docsRegex.exec(contents)) !== null) {
         if (m && m.groups && m.groups.name && m.groups.doc && m.groups.pre) {

--- a/src/utils/execPath.ts
+++ b/src/utils/execPath.ts
@@ -1,6 +1,6 @@
 // utils function to resolve executable path
-import * as path from 'path';
-import { ExtensionSettings } from '../interfaces/extensionSettings';
+import * as path from "path";
+import { ExtensionSettings } from "../interfaces/extensionSettings";
 
 /**
  * A method to return the path to the provided executable
@@ -12,7 +12,7 @@ export function getAnsibleCommandExecPath(
   name: string,
   settings: ExtensionSettings
 ): string {
-  return name === 'ansible-lint'
+  return name === "ansible-lint"
     ? settings.ansibleLint.path
     : path.join(path.dirname(settings.ansible.path), name);
 }

--- a/src/utils/imagePuller.ts
+++ b/src/utils/imagePuller.ts
@@ -1,6 +1,6 @@
-import * as child_process from 'child_process';
-import { Connection } from 'vscode-languageserver';
-import { WorkspaceFolderContext } from '../services/workspaceManager';
+import * as child_process from "child_process";
+import { Connection } from "vscode-languageserver";
+import { WorkspaceFolderContext } from "../services/workspaceManager";
 
 export class ImagePuller {
   private connection: Connection;
@@ -28,7 +28,7 @@ export class ImagePuller {
 
   public async setupImage(): Promise<boolean> {
     let setupComplete = false;
-    const imageTag = this._containerImage.split(':', 2)[1] || 'latest';
+    const imageTag = this._containerImage.split(":", 2)[1] || "latest";
     const imagePresent = this.checkForImage();
     const pullRequired = this.determinePull(imagePresent, imageTag);
 
@@ -45,13 +45,13 @@ export class ImagePuller {
         const pullCommand = `${this._containerEngine} pull ${this._containerImage}`;
         if (progressTracker) {
           progressTracker.begin(
-            'execution-environment',
+            "execution-environment",
             undefined,
-            'Pulling Ansible execution environment image...'
+            "Pulling Ansible execution environment image..."
           );
         }
         child_process.execSync(pullCommand, {
-          encoding: 'utf-8',
+          encoding: "utf-8",
         });
         this.connection.console.info(
           `Container image '${this._containerImage}' pull successful`
@@ -60,7 +60,7 @@ export class ImagePuller {
       } catch (error) {
         let errorMsg = `Failed to pull container image ${this._containerEngine} with error '${error}'`;
         errorMsg +=
-          'Check the execution environment image name, connectivity to and permissions for the registry, and try again';
+          "Check the execution environment image name, connectivity to and permissions for the registry, and try again";
         this.connection.console.error(errorMsg);
         setupComplete = false;
       }
@@ -76,13 +76,13 @@ export class ImagePuller {
 
   private determinePull(imagePresent: boolean, imageTag: string): boolean {
     let pull: boolean;
-    if (this._pullPolicy === 'missing' && !imagePresent) {
+    if (this._pullPolicy === "missing" && !imagePresent) {
       pull = true;
-    } else if (this._pullPolicy === 'always') {
+    } else if (this._pullPolicy === "always") {
       pull = true;
-    } else if (this._pullPolicy === 'tag' && imageTag === 'latest') {
+    } else if (this._pullPolicy === "tag" && imageTag === "latest") {
       pull = true;
-    } else if (this._pullPolicy === 'tag' && !imagePresent) {
+    } else if (this._pullPolicy === "tag" && !imagePresent) {
       pull = true;
     } else {
       pull = false;
@@ -97,7 +97,7 @@ export class ImagePuller {
         `check for container image with command: '${command}'`
       );
       child_process.execSync(command, {
-        encoding: 'utf-8',
+        encoding: "utf-8",
       });
       return true;
     } catch (error) {

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,9 +1,9 @@
-import * as child_process from 'child_process';
-import { promises as fs } from 'fs';
-import { promisify } from 'util';
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import { Range } from 'vscode-languageserver-types';
-import * as path from 'path';
+import * as child_process from "child_process";
+import { promises as fs } from "fs";
+import { promisify } from "util";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { Range } from "vscode-languageserver-types";
+import * as path from "path";
 
 export async function fileExists(filePath: string): Promise<boolean> {
   return !!(await fs.stat(filePath).catch(() => false));
@@ -31,7 +31,7 @@ export function hasOwnProperty<X, Y extends PropertyKey>(
  * Checks whether `obj` is a non-null object.
  */
 export function isObject<X>(obj: X): obj is X & Record<PropertyKey, unknown> {
-  return obj && typeof obj === 'object';
+  return obj && typeof obj === "object";
 }
 
 export function insert(str: string, index: number, val: string): string {
@@ -50,7 +50,7 @@ export function withInterpreter(
   let command = `${executable} ${args}`; // base case
 
   const newEnv = Object.assign({}, process.env, {
-    ANSIBLE_FORCE_COLOR: '0', // ensure output is parseable (no ANSI)
+    ANSIBLE_FORCE_COLOR: "0", // ensure output is parseable (no ANSI)
   });
 
   if (activationScript) {
@@ -59,9 +59,9 @@ export function withInterpreter(
   }
 
   if (interpreterPath) {
-    const virtualEnv = path.resolve(interpreterPath, '../..');
+    const virtualEnv = path.resolve(interpreterPath, "../..");
 
-    const pathEntry = path.join(virtualEnv, 'bin');
+    const pathEntry = path.join(virtualEnv, "bin");
     if (path.isAbsolute(executable)) {
       // if both interpreter path and absolute command path are provided, we can
       // bolster the chances of success by letting the interpreter execute the
@@ -70,8 +70,8 @@ export function withInterpreter(
     }
 
     // emulating virtual environment activation script
-    newEnv['VIRTUAL_ENV'] = virtualEnv;
-    newEnv['PATH'] = `${pathEntry}:${process.env.PATH}`;
+    newEnv["VIRTUAL_ENV"] = virtualEnv;
+    newEnv["PATH"] = `${pathEntry}:${process.env.PATH}`;
     delete newEnv.PYTHONHOME;
   }
   return [command, newEnv];
@@ -83,7 +83,7 @@ export function withInterpreter(
  */
 export function getUnsupportedError(): string | undefined {
   // win32 applies to x64 arch too, is the platform name
-  if (process.platform === 'win32') {
-    return 'Ansible Language Server can only run inside WSL on Windows. Refer to vscode documentation for more details.';
+  if (process.platform === "win32") {
+    return "Ansible Language Server can only run inside WSL on Windows. Refer to vscode documentation for more details.";
   }
 }

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,11 +1,11 @@
-import * as _ from 'lodash';
-import { Position, TextDocument } from 'vscode-languageserver-textdocument';
-import { Document, Options, parseCST } from 'yaml';
-import { Node, Pair, Scalar, YAMLMap, YAMLSeq } from 'yaml/types';
-import { IModuleMetadata, IOption } from '../interfaces/module';
-import { DocsLibrary } from '../services/docsLibrary';
-import { isTaskKeyword, playExclusiveKeywords } from './ansible';
-import { playKeywords, taskKeywords } from '../utils/ansible';
+import * as _ from "lodash";
+import { Position, TextDocument } from "vscode-languageserver-textdocument";
+import { Document, Options, parseCST } from "yaml";
+import { Node, Pair, Scalar, YAMLMap, YAMLSeq } from "yaml/types";
+import { IModuleMetadata, IOption } from "../interfaces/module";
+import { DocsLibrary } from "../services/docsLibrary";
+import { isTaskKeyword, playExclusiveKeywords } from "./ansible";
+import { playKeywords, taskKeywords } from "../utils/ansible";
 
 /**
  * A helper class used for building YAML path assertions and retrieving parent
@@ -79,7 +79,7 @@ export class AncestryBuilder<N extends Node | Pair = Node> {
     if (
       node instanceof Pair &&
       node.key instanceof Scalar &&
-      typeof node.key.value === 'string'
+      typeof node.key.value === "string"
     ) {
       return node.key.value;
     }
@@ -274,7 +274,7 @@ function getDeclaredCollectionsForMap(playNode: YAMLMap | null): string[] {
   const declaredCollections: string[] = [];
   const collectionsPair = _.find(
     playNode?.items,
-    (pair) => pair.key instanceof Scalar && pair.key.value === 'collections'
+    (pair) => pair.key instanceof Scalar && pair.key.value === "collections"
   );
 
   if (collectionsPair) {
@@ -334,7 +334,7 @@ export function isBlockParam(path: Node[]): boolean {
   const isInYAMLSeq = !!builder.parent(YAMLSeq).get();
   if (mapNode && isInYAMLSeq) {
     const providedKeys = getYamlMapKeys(mapNode);
-    return providedKeys.includes('block');
+    return providedKeys.includes("block");
   }
   return false;
 }
@@ -348,7 +348,7 @@ export function isRoleParam(path: Node[]): boolean {
     .parent(YAMLSeq)
     .parent(YAMLMap)
     .getStringKey();
-  return rolesKey === 'roles';
+  return rolesKey === "roles";
 }
 
 /**
@@ -365,7 +365,7 @@ export async function getPossibleOptionsForPath(
   if (!taskParamPath) return null;
 
   const optionTraceElement = suboptionTrace.pop();
-  if (!optionTraceElement || optionTraceElement[1] !== 'dict') {
+  if (!optionTraceElement || optionTraceElement[1] !== "dict") {
     // that element must always be a `dict`
     // (unlike for sub-options, which can also be a 'list')
     return null;
@@ -377,7 +377,7 @@ export async function getPossibleOptionsForPath(
 
   let module;
   // Module options can either be directly under module or in 'args'
-  if (taskParamNode.value === 'args') {
+  if (taskParamNode.value === "args") {
     module = await findProvidedModule(taskParamPath, document, docsLibrary);
   } else {
     [module] = await docsLibrary.findModule(
@@ -410,8 +410,8 @@ export async function getPossibleOptionsForPath(
  */
 export function getTaskParamPathWithTrace(
   path: Node[]
-): [Node[], [string, 'list' | 'dict'][]] {
-  const trace: [string, 'list' | 'dict'][] = [];
+): [Node[], [string, "list" | "dict"][]] {
+  const trace: [string, "list" | "dict"][] = [];
   while (!isTaskParam(path)) {
     let parentKeyPath = new AncestryBuilder(path)
       .parentOfKey()
@@ -421,9 +421,9 @@ export function getTaskParamPathWithTrace(
       const parentKeyNode = parentKeyPath[parentKeyPath.length - 1];
       if (
         parentKeyNode instanceof Scalar &&
-        typeof parentKeyNode.value === 'string'
+        typeof parentKeyNode.value === "string"
       ) {
-        trace.push([parentKeyNode.value, 'dict']);
+        trace.push([parentKeyNode.value, "dict"]);
         path = parentKeyPath;
         continue;
       }
@@ -437,9 +437,9 @@ export function getTaskParamPathWithTrace(
       const parentKeyNode = parentKeyPath[parentKeyPath.length - 1];
       if (
         parentKeyNode instanceof Scalar &&
-        typeof parentKeyNode.value === 'string'
+        typeof parentKeyNode.value === "string"
       ) {
-        trace.push([parentKeyNode.value, 'list']);
+        trace.push([parentKeyNode.value, "list"]);
         path = parentKeyPath;
         continue;
       }

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,31 +1,31 @@
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import * as path from 'path';
-import { promises as fs } from 'fs';
-import { WorkspaceManager } from '../src/services/workspaceManager';
-import { createConnection, TextDocuments } from 'vscode-languageserver/node';
-import { ValidationManager } from '../src/services/validationManager';
+import { TextDocument } from "vscode-languageserver-textdocument";
+import * as path from "path";
+import { promises as fs } from "fs";
+import { WorkspaceManager } from "../src/services/workspaceManager";
+import { createConnection, TextDocuments } from "vscode-languageserver/node";
+import { ValidationManager } from "../src/services/validationManager";
 
-const FIXTURES_BASE_PATH = path.join('test', 'fixtures');
+const FIXTURES_BASE_PATH = path.join("test", "fixtures");
 
 export function setFixtureAnsibleCollectionPathEnv(): void {
   process.env.ANSIBLE_COLLECTIONS_PATHS = path.resolve(
     FIXTURES_BASE_PATH,
-    'common',
-    'collections'
+    "common",
+    "collections"
   );
 }
 
 export async function getDoc(filename: string): Promise<TextDocument> {
   const file = await fs.readFile(path.resolve(FIXTURES_BASE_PATH, filename), {
-    encoding: 'utf8',
+    encoding: "utf8",
   });
   const docUri = path.resolve(FIXTURES_BASE_PATH, filename).toString();
-  return TextDocument.create(docUri, 'ansible', 1, file);
+  return TextDocument.create(docUri, "ansible", 1, file);
 }
 
 export function isWindows(): boolean {
   // win32 applies to x64 arch too, is the platform name
-  return process.platform === 'win32';
+  return process.platform === "win32";
 }
 
 /**
@@ -33,7 +33,7 @@ export function isWindows(): boolean {
  * @returns {WorkspaceManager} object to serve as a workspace manager for testing purposes
  */
 export function createTestWorkspaceManager(): WorkspaceManager {
-  process.argv.push('--node-ipc');
+  process.argv.push("--node-ipc");
   const connection = createConnection();
   const workspaceManager = new WorkspaceManager(connection);
 
@@ -48,7 +48,7 @@ export function createTestWorkspaceManager(): WorkspaceManager {
 }
 
 export function createTestValidationManager(): ValidationManager {
-  process.argv.push('--node-ipc');
+  process.argv.push("--node-ipc");
   const connection = createConnection();
 
   const documents: TextDocuments<TextDocument> = new TextDocuments(

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,6 @@
 // This file is loaded automatically by mocha during the test run.
-import { isWindows } from './helper';
-import { execSync } from 'child_process';
+import { isWindows } from "./helper";
+import { execSync } from "child_process";
 
 // Error code returned if we cannot even start testing:
 const PRETEST_ERR_RC = 2;
@@ -8,12 +8,12 @@ const PRETEST_ERR_RC = 2;
 // isWindows returns false under WSL
 if (isWindows()) {
   console.error(
-    'ERROR: This project does not support pure Windows, try under WSL2.'
+    "ERROR: This project does not support pure Windows, try under WSL2."
   );
   process.exit(PRETEST_ERR_RC);
 }
 
-const command = 'ansible-lint --version';
+const command = "ansible-lint --version";
 try {
   const result = execSync(command);
   console.info(`Detected: ${result}`);

--- a/test/providers/hoverProvider.test.ts
+++ b/test/providers/hoverProvider.test.ts
@@ -1,39 +1,39 @@
-import { expect } from 'chai';
+import { expect } from "chai";
 import {
   createTestWorkspaceManager,
   getDoc,
   setFixtureAnsibleCollectionPathEnv,
-} from '../helper';
-import { doHover } from '../../src/providers/hoverProvider';
-import { Position } from 'vscode-languageserver';
+} from "../helper";
+import { doHover } from "../../src/providers/hoverProvider";
+import { Position } from "vscode-languageserver";
 
 setFixtureAnsibleCollectionPathEnv();
 
-describe('doHover()', () => {
+describe("doHover()", () => {
   const workspaceManager = createTestWorkspaceManager();
 
-  describe('Play keywords hover', () => {
+  describe("Play keywords hover", () => {
     const tests = [
       {
-        word: 'name',
+        word: "name",
         position: { line: 0, character: 4 } as Position,
-        doc: 'Identifier. Can be used for documentation, or in tasks/handlers.',
+        doc: "Identifier. Can be used for documentation, or in tasks/handlers.",
       },
       {
-        word: 'host',
+        word: "host",
         position: { line: 1, character: 4 } as Position,
-        doc: 'A list of groups, hosts or host pattern that translates into a list of hosts that are the play’s target.',
+        doc: "A list of groups, hosts or host pattern that translates into a list of hosts that are the play’s target.",
       },
       {
-        word: 'tasks',
+        word: "tasks",
         position: { line: 3, character: 4 } as Position,
-        doc: 'Main list of tasks to execute in the play, they run after roles and before post_tasks.',
+        doc: "Main list of tasks to execute in the play, they run after roles and before post_tasks.",
       },
     ];
 
     tests.forEach(({ word, position, doc }) => {
       it(`should provide hovering for '${word}'`, async function () {
-        const textDoc = await getDoc('hover/tasks.yml');
+        const textDoc = await getDoc("hover/tasks.yml");
         const context = workspaceManager.getContext(textDoc.uri);
 
         const actualHover = await doHover(
@@ -41,23 +41,23 @@ describe('doHover()', () => {
           position,
           await context.docsLibrary
         );
-        expect(actualHover.contents['value']).includes(doc);
+        expect(actualHover.contents["value"]).includes(doc);
       });
     });
   });
 
-  describe('Task keywords hover', () => {
+  describe("Task keywords hover", () => {
     const tests = [
       {
-        word: 'register',
+        word: "register",
         position: { line: 6, character: 8 } as Position,
-        doc: 'Name of variable that will contain task status and module return data.',
+        doc: "Name of variable that will contain task status and module return data.",
       },
     ];
 
     tests.forEach(({ word, position, doc }) => {
       it(`should provide hovering for '${word}'`, async function () {
-        const textDoc = await getDoc('hover/tasks.yml');
+        const textDoc = await getDoc("hover/tasks.yml");
         const context = workspaceManager.getContext(textDoc.uri);
 
         const actualHover = await doHover(
@@ -65,23 +65,23 @@ describe('doHover()', () => {
           position,
           await context.docsLibrary
         );
-        expect(actualHover.contents['value']).includes(doc);
+        expect(actualHover.contents["value"]).includes(doc);
       });
     });
   });
 
-  describe('Block keywords hover', () => {
+  describe("Block keywords hover", () => {
     const tests = [
       {
-        word: 'become',
+        word: "become",
         position: { line: 11, character: 8 } as Position,
-        doc: 'Boolean that controls if privilege escalation is used or not on Task execution. Implemented by the become plugin.',
+        doc: "Boolean that controls if privilege escalation is used or not on Task execution. Implemented by the become plugin.",
       },
     ];
 
     tests.forEach(({ word, position, doc }) => {
       it(`should provide hovering for '${word}'`, async function () {
-        const textDoc = await getDoc('hover/tasks.yml');
+        const textDoc = await getDoc("hover/tasks.yml");
         const context = workspaceManager.getContext(textDoc.uri);
 
         const actualHover = await doHover(
@@ -89,23 +89,23 @@ describe('doHover()', () => {
           position,
           await context.docsLibrary
         );
-        expect(actualHover.contents['value']).includes(doc);
+        expect(actualHover.contents["value"]).includes(doc);
       });
     });
   });
 
-  describe('Role keywords hover', () => {
+  describe("Role keywords hover", () => {
     const tests = [
       {
-        word: 'tags',
+        word: "tags",
         position: { line: 6, character: 8 } as Position,
-        doc: 'Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line.',
+        doc: "Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line.",
       },
     ];
 
     tests.forEach(({ word, position, doc }) => {
       it(`should provide hovering for '${word}'`, async function () {
-        const textDoc = await getDoc('hover/roles.yml');
+        const textDoc = await getDoc("hover/roles.yml");
         const context = workspaceManager.getContext(textDoc.uri);
 
         const actualHover = await doHover(
@@ -113,28 +113,28 @@ describe('doHover()', () => {
           position,
           await context.docsLibrary
         );
-        expect(actualHover.contents['value']).includes(doc);
+        expect(actualHover.contents["value"]).includes(doc);
       });
     });
   });
 
-  describe('Module name and options hover', () => {
+  describe("Module name and options hover", () => {
     const tests = [
       {
-        word: 'ansible.builtin.debug',
+        word: "ansible.builtin.debug",
         position: { line: 4, character: 8 } as Position,
-        doc: 'Print statements during execution',
+        doc: "Print statements during execution",
       },
       {
-        word: 'ansible.builtin.debug -> msg',
+        word: "ansible.builtin.debug -> msg",
         position: { line: 5, character: 10 } as Position,
-        doc: 'The customized message that is printed. If omitted, prints a generic message.',
+        doc: "The customized message that is printed. If omitted, prints a generic message.",
       },
     ];
 
     tests.forEach(({ word, position, doc }) => {
       it(`should provide hovering for '${word}'`, async function () {
-        const textDoc = await getDoc('hover/tasks.yml');
+        const textDoc = await getDoc("hover/tasks.yml");
         const context = workspaceManager.getContext(textDoc.uri);
 
         const actualHover = await doHover(
@@ -142,14 +142,14 @@ describe('doHover()', () => {
           position,
           await context.docsLibrary
         );
-        expect(actualHover.contents['value']).includes(doc);
+        expect(actualHover.contents["value"]).includes(doc);
       });
     });
   });
 
-  describe('No hover', () => {
-    it('should not provide hovering for values', async function () {
-      const textDoc = await getDoc('hover/tasks.yml');
+  describe("No hover", () => {
+    it("should not provide hovering for values", async function () {
+      const textDoc = await getDoc("hover/tasks.yml");
       const context = workspaceManager.getContext(textDoc.uri);
 
       const actualHover = await doHover(
@@ -160,8 +160,8 @@ describe('doHover()', () => {
       expect(actualHover).to.be.null;
     });
 
-    it('should not provide hovering for improper module name and options', async function () {
-      const textDoc = await getDoc('hover/tasks.yml');
+    it("should not provide hovering for improper module name and options", async function () {
+      const textDoc = await getDoc("hover/tasks.yml");
       const context = workspaceManager.getContext(textDoc.uri);
 
       const actualHover = await doHover(
@@ -172,8 +172,8 @@ describe('doHover()', () => {
       expect(actualHover).to.be.null;
     });
 
-    it('should not provide hovering for improper module option', async function () {
-      const textDoc = await getDoc('hover/tasks.yml');
+    it("should not provide hovering for improper module option", async function () {
+      const textDoc = await getDoc("hover/tasks.yml");
       const context = workspaceManager.getContext(textDoc.uri);
 
       const actualHover = await doHover(

--- a/test/providers/validationProvider.test.ts
+++ b/test/providers/validationProvider.test.ts
@@ -1,25 +1,25 @@
-import { expect } from 'chai';
-import { Position, integer } from 'vscode-languageserver';
+import { expect } from "chai";
+import { Position, integer } from "vscode-languageserver";
 import {
   doValidate,
   getYamlValidation,
-} from '../../src/providers/validationProvider';
+} from "../../src/providers/validationProvider";
 import {
   createTestValidationManager,
   createTestWorkspaceManager,
   getDoc,
   setFixtureAnsibleCollectionPathEnv,
-} from '../helper';
+} from "../helper";
 
 setFixtureAnsibleCollectionPathEnv();
 
-describe('doValidate()', () => {
+describe("doValidate()", () => {
   const workspaceManager = createTestWorkspaceManager();
   const validationManager = createTestValidationManager();
 
-  describe('Get validation only from cache', () => {
-    it('should provide no diagnostics', async function () {
-      const textDoc = await getDoc('diagnostics/lint_errors.yml');
+  describe("Get validation only from cache", () => {
+    it("should provide no diagnostics", async function () {
+      const textDoc = await getDoc("diagnostics/lint_errors.yml");
 
       const actualDiagnostics = await doValidate(textDoc, validationManager);
 
@@ -27,16 +27,16 @@ describe('doValidate()', () => {
     });
   });
 
-  describe('Ansible diagnostics', () => {
-    describe('Diagnostics using ansible-lint', () => {
+  describe("Ansible diagnostics", () => {
+    describe("Diagnostics using ansible-lint", () => {
       const tests = [
         {
-          name: 'specific ansible lint errors',
-          file: 'diagnostics/lint_errors.yml',
+          name: "specific ansible lint errors",
+          file: "diagnostics/lint_errors.yml",
           diagnosticReport: [
             {
               severity: 1,
-              message: 'violates variable naming standards',
+              message: "violates variable naming standards",
               range: {
                 start: { line: 4, character: 0 } as Position,
                 end: {
@@ -44,11 +44,11 @@ describe('doValidate()', () => {
                   character: integer.MAX_VALUE,
                 } as Position,
               },
-              source: 'Ansible',
+              source: "Ansible",
             },
             {
               severity: 1,
-              message: 'All tasks should be named',
+              message: "All tasks should be named",
               range: {
                 start: { line: 6, character: 0 } as Position,
                 end: {
@@ -56,7 +56,7 @@ describe('doValidate()', () => {
                   character: integer.MAX_VALUE,
                 } as Position,
               },
-              source: 'Ansible',
+              source: "Ansible",
             },
             {
               severity: 1,
@@ -69,12 +69,12 @@ describe('doValidate()', () => {
                   character: integer.MAX_VALUE,
                 } as Position,
               },
-              source: 'Ansible',
+              source: "Ansible",
             },
             {
               severity: 1,
               message:
-                'Commands should not change things if nothing needs doing',
+                "Commands should not change things if nothing needs doing",
               range: {
                 start: { line: 14, character: 0 } as Position,
                 end: {
@@ -82,17 +82,17 @@ describe('doValidate()', () => {
                   character: integer.MAX_VALUE,
                 } as Position,
               },
-              source: 'Ansible',
+              source: "Ansible",
             },
           ],
         },
         {
-          name: 'empty playbook',
-          file: 'diagnostics/empty.yml',
+          name: "empty playbook",
+          file: "diagnostics/empty.yml",
           diagnosticReport: [
             {
               severity: 1,
-              message: '[syntax-check] Empty playbook, nothing to do',
+              message: "[syntax-check] Empty playbook, nothing to do",
               range: {
                 start: { line: 0, character: 0 } as Position,
                 end: {
@@ -100,17 +100,17 @@ describe('doValidate()', () => {
                   character: integer.MAX_VALUE,
                 } as Position,
               },
-              source: 'Ansible',
+              source: "Ansible",
             },
           ],
         },
         {
-          name: 'no host',
-          file: 'diagnostics/noHost.yml',
+          name: "no host",
+          file: "diagnostics/noHost.yml",
           diagnosticReport: [
             {
               severity: 1,
-              message: '[syntax-check] Ansible syntax check failed',
+              message: "[syntax-check] Ansible syntax check failed",
               range: {
                 start: { line: 0, character: 0 } as Position,
                 end: {
@@ -118,7 +118,7 @@ describe('doValidate()', () => {
                   character: integer.MAX_VALUE,
                 } as Position,
               },
-              source: 'Ansible',
+              source: "Ansible",
             },
           ],
         },
@@ -159,21 +159,21 @@ describe('doValidate()', () => {
       });
     });
 
-    describe('Diagnostics after falling back to --syntax-check due to change in settings', () => {
+    describe("Diagnostics after falling back to --syntax-check due to change in settings", () => {
       const tests = [
         {
-          name: 'no specific ansible lint errors',
-          file: 'diagnostics/lint_errors.yml',
+          name: "no specific ansible lint errors",
+          file: "diagnostics/lint_errors.yml",
           diagnosticReport: [],
         },
         {
-          name: 'empty playbook',
-          file: 'diagnostics/empty.yml',
+          name: "empty playbook",
+          file: "diagnostics/empty.yml",
           diagnosticReport: [],
         },
         {
-          name: 'no host',
-          file: 'diagnostics/noHost.yml',
+          name: "no host",
+          file: "diagnostics/noHost.yml",
           diagnosticReport: [
             {
               severity: 1,
@@ -186,7 +186,7 @@ describe('doValidate()', () => {
                   character: integer.MAX_VALUE,
                 } as Position,
               },
-              source: 'Ansible',
+              source: "Ansible",
             },
           ],
         },
@@ -233,16 +233,16 @@ describe('doValidate()', () => {
         });
       });
     });
-    describe('Diagnostics after falling back to --syntax-check due to unavailability of ansible-lint', () => {
+    describe("Diagnostics after falling back to --syntax-check due to unavailability of ansible-lint", () => {
       const tests = [
         {
-          name: 'no specific ansible lint errors',
-          file: 'diagnostics/lint_errors.yml',
+          name: "no specific ansible lint errors",
+          file: "diagnostics/lint_errors.yml",
           diagnosticReport: [],
         },
         {
-          name: 'no host',
-          file: 'diagnostics/noHost.yml',
+          name: "no host",
+          file: "diagnostics/noHost.yml",
           diagnosticReport: [
             {
               severity: 1,
@@ -255,7 +255,7 @@ describe('doValidate()', () => {
                   character: integer.MAX_VALUE,
                 } as Position,
               },
-              source: 'Ansible',
+              source: "Ansible",
             },
           ],
         },
@@ -269,7 +269,7 @@ describe('doValidate()', () => {
           //   Update setting to disable ansible-lint
           const docSettings = context.documentSettings.get(textDoc.uri);
           const cachedDefaultSetting = (await docSettings).ansibleLint.path;
-          (await docSettings).ansibleLint.path = 'invalid-ansible-lint-path';
+          (await docSettings).ansibleLint.path = "invalid-ansible-lint-path";
 
           const actualDiagnostics = await doValidate(
             textDoc,
@@ -304,16 +304,16 @@ describe('doValidate()', () => {
       });
     });
 
-    describe('Diagnostics after falling back to --syntax-check due to failure in execution of ansible-lint command', () => {
+    describe("Diagnostics after falling back to --syntax-check due to failure in execution of ansible-lint command", () => {
       const tests = [
         {
-          name: 'no specific ansible lint errors',
-          file: 'diagnostics/lint_errors.yml',
+          name: "no specific ansible lint errors",
+          file: "diagnostics/lint_errors.yml",
           diagnosticReport: [],
         },
         {
-          name: 'no host',
-          file: 'diagnostics/noHost.yml',
+          name: "no host",
+          file: "diagnostics/noHost.yml",
           diagnosticReport: [
             {
               severity: 1,
@@ -326,7 +326,7 @@ describe('doValidate()', () => {
                   character: integer.MAX_VALUE,
                 } as Position,
               },
-              source: 'Ansible',
+              source: "Ansible",
             },
           ],
         },
@@ -341,7 +341,7 @@ describe('doValidate()', () => {
           const docSettings = context.documentSettings.get(textDoc.uri);
           const cachedDefaultSetting = (await docSettings).ansibleLint
             .arguments;
-          (await docSettings).ansibleLint.arguments = '-f invalid_argument';
+          (await docSettings).ansibleLint.arguments = "-f invalid_argument";
 
           const actualDiagnostics = await doValidate(
             textDoc,
@@ -376,15 +376,15 @@ describe('doValidate()', () => {
     });
   });
 
-  describe('YAML diagnostics', () => {
+  describe("YAML diagnostics", () => {
     const tests = [
       {
-        name: 'invalid YAML',
-        file: 'diagnostics/invalid_yaml.yml',
+        name: "invalid YAML",
+        file: "diagnostics/invalid_yaml.yml",
         diagnosticReport: [
           {
             severity: 1,
-            message: 'Nested mappings are not allowed',
+            message: "Nested mappings are not allowed",
             range: {
               start: { line: 6, character: 13 } as Position,
               end: {
@@ -392,11 +392,11 @@ describe('doValidate()', () => {
                 character: 13,
               } as Position,
             },
-            source: 'Ansible [YAML]',
+            source: "Ansible [YAML]",
           },
           {
             severity: 1,
-            message: 'Document contains trailing content',
+            message: "Document contains trailing content",
             range: {
               start: { line: 7, character: 0 } as Position,
               end: {
@@ -404,7 +404,7 @@ describe('doValidate()', () => {
                 character: 0,
               } as Position,
             },
-            source: 'Ansible [YAML]',
+            source: "Ansible [YAML]",
           },
         ],
       },

--- a/test/utils/runCommand.test.ts
+++ b/test/utils/runCommand.test.ts
@@ -1,49 +1,49 @@
-import { CommandRunner } from '../../src/utils/commandRunner';
-import { AssertionError, expect } from 'chai';
-import { WorkspaceManager } from '../../src/services/workspaceManager';
-import { createConnection } from 'vscode-languageserver/node';
-import { getDoc } from '../helper';
+import { CommandRunner } from "../../src/utils/commandRunner";
+import { AssertionError, expect } from "chai";
+import { WorkspaceManager } from "../../src/services/workspaceManager";
+import { createConnection } from "vscode-languageserver/node";
+import { getDoc } from "../helper";
 
-describe('commandRunner', () => {
+describe("commandRunner", () => {
   const tests = [
     {
-      args: ['ansible-config', 'dump'],
+      args: ["ansible-config", "dump"],
       rc: 0,
-      stdout: 'ANSIBLE_FORCE_COLOR',
-      stderr: '',
+      stdout: "ANSIBLE_FORCE_COLOR",
+      stderr: "",
     },
     {
-      args: ['ansible', '--version'],
+      args: ["ansible", "--version"],
       rc: 0,
-      stdout: 'configured module search path',
-      stderr: '',
+      stdout: "configured module search path",
+      stderr: "",
     },
     {
-      args: ['ansible-lint', '--version'],
+      args: ["ansible-lint", "--version"],
       rc: 0,
-      stdout: 'using ansible',
-      stderr: '',
+      stdout: "using ansible",
+      stderr: "",
     },
     {
-      args: ['ansible-playbook', 'missing-file'],
+      args: ["ansible-playbook", "missing-file"],
       rc: 1,
-      stdout: '',
-      stderr: 'ERROR! the playbook: missing-file could not be found',
+      stdout: "",
+      stderr: "ERROR! the playbook: missing-file could not be found",
     },
   ];
 
   tests.forEach(({ args, rc, stdout, stderr }) => {
-    it(`call ${args.join(' ')}`, async function () {
+    it(`call ${args.join(" ")}`, async function () {
       this.timeout(10000);
 
       // try to enforce ansible to output ANSI in order to check if we are
       // still able to disable it at runtime in order to keep output parseable.
-      process.env.ANSIBLE_FORCE_COLOR = '1';
+      process.env.ANSIBLE_FORCE_COLOR = "1";
 
-      process.argv.push('--node-ipc');
+      process.argv.push("--node-ipc");
       const connection = createConnection();
       const workspaceManager = new WorkspaceManager(connection);
-      const textDoc = await getDoc('yaml/ancestryBuilder.yml');
+      const textDoc = await getDoc("yaml/ancestryBuilder.yml");
       const context = workspaceManager.getContext(textDoc.uri);
       const settings = await context.documentSettings.get(textDoc.uri);
 
@@ -51,7 +51,7 @@ describe('commandRunner', () => {
       try {
         const proc = await commandRunner.runCommand(
           args[0],
-          args.slice(1).join(' ')
+          args.slice(1).join(" ")
         );
         expect(proc.stdout, proc.stderr).contains(stdout);
         expect(proc.stderr, proc.stdout).contains(stderr);

--- a/test/utils/yaml.test.ts
+++ b/test/utils/yaml.test.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import { Node, Scalar, YAMLMap, YAMLSeq } from 'yaml/types';
+import { expect } from "chai";
+import { Node, Scalar, YAMLMap, YAMLSeq } from "yaml/types";
 import {
   AncestryBuilder,
   getDeclaredCollections,
@@ -9,8 +9,8 @@ import {
   isRoleParam,
   isTaskParam,
   parseAllDocuments,
-} from '../../src/utils/yaml';
-import { getDoc, isWindows } from '../helper';
+} from "../../src/utils/yaml";
+import { getDoc, isWindows } from "../helper";
 
 async function getPathInFile(
   yamlFile: string,
@@ -26,7 +26,7 @@ async function getPathInFile(
   );
 }
 
-describe('yaml', () => {
+describe("yaml", () => {
   beforeEach(function () {
     const brokenTests = new Map([
       // ['<testName>', '<url-of-tracking-issue>'],
@@ -43,53 +43,53 @@ describe('yaml', () => {
     }
   });
 
-  describe('ancestryBuilder', () => {
-    it('canGetParent', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 4, 7);
+  describe("ancestryBuilder", () => {
+    it("canGetParent", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
       const node = new AncestryBuilder(path).parent().get();
       expect(node).to.be.an.instanceOf(YAMLMap);
     });
 
-    it('canGetAssertedParent', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 4, 7);
+    it("canGetAssertedParent", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
       const node = new AncestryBuilder(path).parent(YAMLMap).get();
       expect(node).to.be.an.instanceOf(YAMLMap);
     });
 
-    it('canAssertParent', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 4, 7);
+    it("canAssertParent", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
       const node = new AncestryBuilder(path).parent(YAMLSeq).get();
       expect(node).to.be.null;
     });
 
-    it('canGetAncestor', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 4, 7);
+    it("canGetAncestor", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
       const node = new AncestryBuilder(path).parent().parent().get();
       expect(node).to.be.an.instanceOf(YAMLSeq);
     });
 
-    it('canGetParentPath', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 4, 7);
+    it("canGetParentPath", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
       const subPath = new AncestryBuilder(path).parent().getPath();
       expect(subPath)
         .to.be.an.instanceOf(Array)
         .to.have.lengthOf((path?.length || 0) - 2);
     });
 
-    it('canGetKey', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 4, 7);
+    it("canGetKey", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
       const key = new AncestryBuilder(path).parent(YAMLMap).getStringKey();
-      expect(key).to.be.equal('name');
+      expect(key).to.be.equal("name");
     });
 
-    it('canGetKeyForValue', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 4, 13);
+    it("canGetKeyForValue", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 4, 13);
       const key = new AncestryBuilder(path).parent(YAMLMap).getStringKey();
-      expect(key).to.be.equal('name');
+      expect(key).to.be.equal("name");
     });
 
-    it('canGetKeyPath', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 4, 7);
+    it("canGetKeyPath", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
       const subPath = new AncestryBuilder(path).parent(YAMLMap).getKeyPath();
       expect(subPath)
         .to.be.an.instanceOf(Array)
@@ -97,263 +97,263 @@ describe('yaml', () => {
       if (subPath)
         expect(subPath[subPath.length - 1])
           .to.be.an.instanceOf(Scalar)
-          .to.have.property('value', 'name');
+          .to.have.property("value", "name");
     });
 
-    it('canGetAssertedParentOfKey', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 4, 7);
+    it("canGetAssertedParentOfKey", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 4, 7);
       const node = new AncestryBuilder(path).parentOfKey().get();
       expect(node).to.be.an.instanceOf(YAMLMap);
-      expect(node).to.have.nested.property('items[0].key.value', 'name');
+      expect(node).to.have.nested.property("items[0].key.value", "name");
     });
 
-    it('canAssertParentOfKey', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 4, 13);
+    it("canAssertParentOfKey", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 4, 13);
       const node = new AncestryBuilder(path).parentOfKey().get();
       expect(node).to.be.null;
     });
 
-    it('canGetIndentationParent', async () => {
-      const path = await getPathInFile('ancestryBuilder.yml', 7, 9);
+    it("canGetIndentationParent", async () => {
+      const path = await getPathInFile("ancestryBuilder.yml", 7, 9);
       const node = new AncestryBuilder(path)
         .parent(YAMLMap)
         .parent(YAMLMap)
         .getStringKey();
-      expect(node).to.be.equal('lineinfile');
+      expect(node).to.be.equal("lineinfile");
     });
 
-    it.skip('canGetIndentationParentAtEndOfMap', async () => {
+    it.skip("canGetIndentationParentAtEndOfMap", async () => {
       // skipped -> the YAML parser doesn't correctly interpret indentation in
       // otherwise empty lines; a workaround is implemented for completion
       // provider
-      const path = await getPathInFile('ancestryBuilder.yml', 9, 9);
+      const path = await getPathInFile("ancestryBuilder.yml", 9, 9);
       const node = new AncestryBuilder(path)
         .parent(YAMLMap)
         .parent(YAMLMap)
         .getStringKey();
-      expect(node).to.be.equal('lineinfile');
+      expect(node).to.be.equal("lineinfile");
     });
 
-    it.skip('canGetIndentationParentAtEOF', async () => {
+    it.skip("canGetIndentationParentAtEOF", async () => {
       // skipped -> the YAML parser doesn't correctly interpret indentation in
       // otherwise empty lines; a workaround is implemented for completion
       // provider
-      const path = await getPathInFile('ancestryBuilder.yml', 15, 9);
+      const path = await getPathInFile("ancestryBuilder.yml", 15, 9);
       const node = new AncestryBuilder(path)
         .parent(YAMLMap)
         .parent(YAMLMap)
         .getStringKey();
-      expect(node).to.be.equal('lineinfile');
+      expect(node).to.be.equal("lineinfile");
     });
   });
 
-  describe('getDeclaredCollections', () => {
-    it('canGetCollections', async () => {
-      const path = await getPathInFile('getDeclaredCollections.yml', 13, 7);
+  describe("getDeclaredCollections", () => {
+    it("canGetCollections", async () => {
+      const path = await getPathInFile("getDeclaredCollections.yml", 13, 7);
       const collections = getDeclaredCollections(path);
       expect(collections).to.have.members([
-        'mynamespace.mycollection',
-        'mynamespace2.mycollection2',
+        "mynamespace.mycollection",
+        "mynamespace2.mycollection2",
       ]);
     });
-    it('canGetCollectionsFromPreTasks', async () => {
-      const path = await getPathInFile('getDeclaredCollections.yml', 9, 7);
+    it("canGetCollectionsFromPreTasks", async () => {
+      const path = await getPathInFile("getDeclaredCollections.yml", 9, 7);
       const collections = getDeclaredCollections(path);
       expect(collections).to.have.members([
-        'mynamespace.mycollection',
-        'mynamespace2.mycollection2',
+        "mynamespace.mycollection",
+        "mynamespace2.mycollection2",
       ]);
     });
-    it('canGetCollectionsFromBlock', async () => {
-      const path = await getPathInFile('getDeclaredCollections.yml', 12, 11);
+    it("canGetCollectionsFromBlock", async () => {
+      const path = await getPathInFile("getDeclaredCollections.yml", 12, 11);
       const collections = getDeclaredCollections(path);
       expect(collections).to.have.members([
-        'mynamespace.mycollection',
-        'mynamespace2.mycollection2',
+        "mynamespace.mycollection",
+        "mynamespace2.mycollection2",
       ]);
     });
-    it('canGetCollectionsFromNestedBlock', async () => {
-      const path = await getPathInFile('getDeclaredCollections.yml', 23, 15);
+    it("canGetCollectionsFromNestedBlock", async () => {
+      const path = await getPathInFile("getDeclaredCollections.yml", 23, 15);
       const collections = getDeclaredCollections(path);
       expect(collections).to.have.members([
-        'mynamespace.mycollection',
-        'mynamespace2.mycollection2',
+        "mynamespace.mycollection",
+        "mynamespace2.mycollection2",
       ]);
     });
-    it('canGetCollectionsFromRescue', async () => {
-      const path = await getPathInFile('getDeclaredCollections.yml', 27, 11);
+    it("canGetCollectionsFromRescue", async () => {
+      const path = await getPathInFile("getDeclaredCollections.yml", 27, 11);
       const collections = getDeclaredCollections(path);
       expect(collections).to.have.members([
-        'mynamespace.mycollection',
-        'mynamespace2.mycollection2',
+        "mynamespace.mycollection",
+        "mynamespace2.mycollection2",
       ]);
     });
-    it('canGetCollectionsFromAlways', async () => {
-      const path = await getPathInFile('getDeclaredCollections.yml', 31, 11);
+    it("canGetCollectionsFromAlways", async () => {
+      const path = await getPathInFile("getDeclaredCollections.yml", 31, 11);
       const collections = getDeclaredCollections(path);
       expect(collections).to.have.members([
-        'mynamespace.mycollection',
-        'mynamespace2.mycollection2',
+        "mynamespace.mycollection",
+        "mynamespace2.mycollection2",
       ]);
     });
-    it('canWorkWithoutCollections', async () => {
-      const path = await getPathInFile('getDeclaredCollections.yml', 38, 7);
+    it("canWorkWithoutCollections", async () => {
+      const path = await getPathInFile("getDeclaredCollections.yml", 38, 7);
       const collections = getDeclaredCollections(path);
       expect(collections).to.have.members([]);
     });
-    it('canWorkWithEmptyCollections', async () => {
-      const path = await getPathInFile('getDeclaredCollections.yml', 46, 7);
+    it("canWorkWithEmptyCollections", async () => {
+      const path = await getPathInFile("getDeclaredCollections.yml", 46, 7);
       const collections = getDeclaredCollections(path);
       expect(collections).to.have.members([]);
     });
   });
 
-  describe('isTaskParam', () => {
-    it('canCorrectlyConfirmTaskParam', async () => {
-      const path = (await getPathInFile('isTaskParam.yml', 3, 3)) as Node[];
+  describe("isTaskParam", () => {
+    it("canCorrectlyConfirmTaskParam", async () => {
+      const path = (await getPathInFile("isTaskParam.yml", 3, 3)) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(true);
     });
 
-    it('canCorrectlyNegateTaskParam', async () => {
-      const path = (await getPathInFile('isTaskParam.yml', 1, 1)) as Node[];
+    it("canCorrectlyNegateTaskParam", async () => {
+      const path = (await getPathInFile("isTaskParam.yml", 1, 1)) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(false);
     });
 
-    it('canCorrectlyNegateTaskParamForValue', async () => {
-      const path = (await getPathInFile('isTaskParam.yml', 2, 9)) as Node[];
+    it("canCorrectlyNegateTaskParamForValue", async () => {
+      const path = (await getPathInFile("isTaskParam.yml", 2, 9)) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(false);
     });
 
-    it('canCorrectlyNegateTaskParamForPlay', async () => {
-      const path = (await getPathInFile('isTaskParam.yml', 7, 3)) as Node[];
+    it("canCorrectlyNegateTaskParamForPlay", async () => {
+      const path = (await getPathInFile("isTaskParam.yml", 7, 3)) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(false);
     });
 
-    it('canCorrectlyNegateTaskParamForBlock', async () => {
-      const path = (await getPathInFile('isTaskParam.yml', 18, 7)) as Node[];
+    it("canCorrectlyNegateTaskParamForBlock", async () => {
+      const path = (await getPathInFile("isTaskParam.yml", 18, 7)) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(false);
     });
 
-    it('canCorrectlyNegateTaskParamForRole', async () => {
-      const path = (await getPathInFile('isTaskParam.yml', 21, 7)) as Node[];
+    it("canCorrectlyNegateTaskParamForRole", async () => {
+      const path = (await getPathInFile("isTaskParam.yml", 21, 7)) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(false);
     });
 
-    it('canCorrectlyConfirmTaskParamInPreTasks', async () => {
-      const path = (await getPathInFile('isTaskParam.yml', 10, 7)) as Node[];
+    it("canCorrectlyConfirmTaskParamInPreTasks", async () => {
+      const path = (await getPathInFile("isTaskParam.yml", 10, 7)) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(true);
     });
 
-    it('canCorrectlyConfirmTaskParamInTasks', async () => {
-      const path = (await getPathInFile('isTaskParam.yml', 13, 7)) as Node[];
+    it("canCorrectlyConfirmTaskParamInTasks", async () => {
+      const path = (await getPathInFile("isTaskParam.yml", 13, 7)) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(true);
     });
 
-    it('canCorrectlyConfirmTaskParamInBlock', async () => {
-      const path = (await getPathInFile('isTaskParam.yml', 17, 11)) as Node[];
+    it("canCorrectlyConfirmTaskParamInBlock", async () => {
+      const path = (await getPathInFile("isTaskParam.yml", 17, 11)) as Node[];
       const test = isTaskParam(path);
       expect(test).to.be.eq(true);
     });
   });
 
-  describe('isPlayParam', () => {
-    it('canCorrectlyConfirmPlayParam', async () => {
-      const path = (await getPathInFile('isPlayParam.yml', 1, 3)) as Node[];
-      const test = isPlayParam(path, 'file://test/isPlay.yml');
+  describe("isPlayParam", () => {
+    it("canCorrectlyConfirmPlayParam", async () => {
+      const path = (await getPathInFile("isPlayParam.yml", 1, 3)) as Node[];
+      const test = isPlayParam(path, "file://test/isPlay.yml");
       expect(test).to.be.eq(true);
     });
-    it('canCorrectlyConfirmPlayParamWithoutPath', async () => {
-      const path = (await getPathInFile('isPlayParam.yml', 1, 3)) as Node[];
+    it("canCorrectlyConfirmPlayParamWithoutPath", async () => {
+      const path = (await getPathInFile("isPlayParam.yml", 1, 3)) as Node[];
       const test = isPlayParam(path);
       expect(test).to.be.eq(true);
     });
 
-    it('canCorrectlyConfirmPlayParamInStrangePath', async () => {
-      const path = (await getPathInFile('isPlayParam.yml', 1, 3)) as Node[];
-      const test = isPlayParam(path, 'file:///roles/test/tasks/isPlay.yml');
+    it("canCorrectlyConfirmPlayParamInStrangePath", async () => {
+      const path = (await getPathInFile("isPlayParam.yml", 1, 3)) as Node[];
+      const test = isPlayParam(path, "file:///roles/test/tasks/isPlay.yml");
       expect(test).to.be.eq(true);
     });
 
-    it('canCorrectlyNegatePlayParamInRolePathWithoutPlayKeywords', async () => {
-      const path = (await getPathInFile('isPlayParam.yml', 7, 3)) as Node[];
-      const test = isPlayParam(path, 'file:///roles/test/tasks/isPlay.yml');
+    it("canCorrectlyNegatePlayParamInRolePathWithoutPlayKeywords", async () => {
+      const path = (await getPathInFile("isPlayParam.yml", 7, 3)) as Node[];
+      const test = isPlayParam(path, "file:///roles/test/tasks/isPlay.yml");
       expect(test).to.be.eq(false);
     });
 
-    it('isIndecisiveWithoutPlayKeywords', async () => {
-      const path = (await getPathInFile('isPlayParam.yml', 7, 3)) as Node[];
-      const test = isPlayParam(path, 'file://test/isPlay.yml');
+    it("isIndecisiveWithoutPlayKeywords", async () => {
+      const path = (await getPathInFile("isPlayParam.yml", 7, 3)) as Node[];
+      const test = isPlayParam(path, "file://test/isPlay.yml");
       expect(test).to.be.eq(undefined);
     });
 
-    it('isIndecisiveWithoutPlayKeywordsWithoutPath', async () => {
-      const path = (await getPathInFile('isPlayParam.yml', 7, 3)) as Node[];
+    it("isIndecisiveWithoutPlayKeywordsWithoutPath", async () => {
+      const path = (await getPathInFile("isPlayParam.yml", 7, 3)) as Node[];
       const test = isPlayParam(path);
       expect(test).to.be.eq(undefined);
     });
 
-    it('canCorrectlyNegatePlayParamForNonRootSequence', async () => {
-      const path = (await getPathInFile('isPlayParam.yml', 14, 7)) as Node[];
-      const test = isPlayParam(path, 'file://test/isPlay.yml');
+    it("canCorrectlyNegatePlayParamForNonRootSequence", async () => {
+      const path = (await getPathInFile("isPlayParam.yml", 14, 7)) as Node[];
+      const test = isPlayParam(path, "file://test/isPlay.yml");
       expect(test).to.be.eq(false);
     });
 
-    it('canCorrectlyNegatePlayParamForNonRootSequenceWithoutPath', async () => {
-      const path = (await getPathInFile('isPlayParam.yml', 14, 7)) as Node[];
+    it("canCorrectlyNegatePlayParamForNonRootSequenceWithoutPath", async () => {
+      const path = (await getPathInFile("isPlayParam.yml", 14, 7)) as Node[];
       const test = isPlayParam(path);
       expect(test).to.be.eq(false);
     });
 
-    it('canCorrectlyNegatePlayParamForValue', async () => {
-      const path = (await getPathInFile('isPlayParam.yml', 1, 9)) as Node[];
+    it("canCorrectlyNegatePlayParamForValue", async () => {
+      const path = (await getPathInFile("isPlayParam.yml", 1, 9)) as Node[];
       const test = isPlayParam(path);
       expect(test).to.be.eq(false);
     });
   });
 
-  describe('isBlockParam', () => {
-    it('canCorrectlyConfirmBlockParam', async () => {
-      const path = (await getPathInFile('isBlockParam.yml', 2, 3)) as Node[];
+  describe("isBlockParam", () => {
+    it("canCorrectlyConfirmBlockParam", async () => {
+      const path = (await getPathInFile("isBlockParam.yml", 2, 3)) as Node[];
       const test = isBlockParam(path);
       expect(test).to.be.eq(true);
     });
 
-    it('canCorrectlyNegateBlockParam', async () => {
-      const path = (await getPathInFile('isBlockParam.yml', 5, 3)) as Node[];
+    it("canCorrectlyNegateBlockParam", async () => {
+      const path = (await getPathInFile("isBlockParam.yml", 5, 3)) as Node[];
       const test = isBlockParam(path);
       expect(test).to.be.eq(false);
     });
 
-    it('canCorrectlyNegateBlockParamOnValue', async () => {
-      const path = (await getPathInFile('isBlockParam.yml', 2, 11)) as Node[];
+    it("canCorrectlyNegateBlockParamOnValue", async () => {
+      const path = (await getPathInFile("isBlockParam.yml", 2, 11)) as Node[];
       const test = isBlockParam(path);
       expect(test).to.be.eq(false);
     });
   });
 
-  describe('isRoleParam', () => {
-    it('canCorrectlyConfirmRoleParam', async () => {
-      const path = (await getPathInFile('isRoleParam.yml', 5, 7)) as Node[];
+  describe("isRoleParam", () => {
+    it("canCorrectlyConfirmRoleParam", async () => {
+      const path = (await getPathInFile("isRoleParam.yml", 5, 7)) as Node[];
       const test = isRoleParam(path);
       expect(test).to.be.eq(true);
     });
 
-    it('canCorrectlyNegateRoleParam', async () => {
-      const path = (await getPathInFile('isRoleParam.yml', 4, 3)) as Node[];
+    it("canCorrectlyNegateRoleParam", async () => {
+      const path = (await getPathInFile("isRoleParam.yml", 4, 3)) as Node[];
       const test = isRoleParam(path);
       expect(test).to.be.eq(false);
     });
 
-    it('canCorrectlyNegateRoleParamOnValue', async () => {
-      const path = (await getPathInFile('isRoleParam.yml', 5, 13)) as Node[];
+    it("canCorrectlyNegateRoleParamOnValue", async () => {
+      const path = (await getPathInFile("isRoleParam.yml", 5, 13)) as Node[];
       const test = isRoleParam(path);
       expect(test).to.be.eq(false);
     });


### PR DESCRIPTION
This change is the last one related to switching to default quoting configuration for our formatters. All other projects are already using the default.

Keep in mind that the only manual modifications from this PR are to`.prettierrc.yaml` and `.eslintrc.json`, the rest is done by pre-commit.

Fixes: https://github.com/ansible-community/devtools/issues/28
Related: https://github.com/ansible/vscode-ansible/pull/407