### PR TITLE
Fix EE intermittent issue with auto-completion

### DIFF
--- a/docs/changelog-fragments.d/263.bugfix.md
+++ b/docs/changelog-fragments.d/263.bugfix.md
@@ -1,0 +1,2 @@
+Fixed intermittent issue with execution environment for auto-completion and hover by waiting for async function to copy plugins from
+within EE to local host cache --{user}`ganeshrn`.

--- a/docs/changelog-fragments.d/263.bugfix.md
+++ b/docs/changelog-fragments.d/263.bugfix.md
@@ -1,2 +1,3 @@
-Fixed intermittent issue with execution environment for auto-completion and hover by waiting for async function to copy plugins from
-within EE to local host cache --{user}`ganeshrn`.
+Fixed intermittent issue with execution environment for auto-completion and
+hover by waiting for async function to copy plugins from within EE to local host
+cache --{user}`ganeshrn`.

--- a/src/services/executionEnvironment.ts
+++ b/src/services/executionEnvironment.ts
@@ -82,7 +82,7 @@ export class ExecutionEnvironment {
         );
         return;
       }
-      this.fetchPluginDocs();
+      await this.fetchPluginDocs();
     } catch (error) {
       if (error instanceof Error) {
         this.connection.window.showErrorMessage(error.message);


### PR DESCRIPTION
*  Wait for async function to copy plugins from
   within EE to local host