### PR TITLE
Update test to handle new ansible-lint error report

### DIFF
--- a/test/providers/validationProvider.test.ts
+++ b/test/providers/validationProvider.test.ts
@@ -60,12 +60,11 @@ describe("doValidate()", () => {
             },
             {
               severity: 1,
-              // eslint-disable-next-line quotes
-              message: "Don't compare to empty string",
+              message: "Use FQCN for builtin actions",
               range: {
-                start: { line: 9, character: 0 } as Position,
+                start: { line: 14, character: 0 } as Position,
                 end: {
-                  line: 9,
+                  line: 14,
                   character: integer.MAX_VALUE,
                 } as Position,
               },


### PR DESCRIPTION
This PR fixes the tests for `doValidate() provider` (that are currently failing) by modifying the fixture data according to the new error messages sent by ansible-lint (version: 6.0.0).

New rule: `[fqcn-builtins] Use FQCN for builtin actions.`

The new version of ansible-lint seems to have removed certain rules as well: 
Removed rule: `Don't compare to empty string`