### PR TITLE
Configure sphinx to always use colors on output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ skipsdist = true
 [docs]
 # do not use continuation with vars, see https://github.com/tox-dev/tox/issues/2069
 sphinx_common_args =
-  -j auto {tty:--color} -a -n -W --keep-going -T -d "{temp_dir}/.doctrees" . "{envdir}/docs_out"
+  # https://github.com/sphinx-doc/sphinx/pull/10260
+  -j auto --color -a -n -W --keep-going -T -d "{temp_dir}/.doctrees" . "{envdir}/docs_out"
 
 [testenv]
 description =


### PR DESCRIPTION
Related: https://github.com/sphinx-doc/sphinx/pull/10260
