### PR TITLE
Fix EE auto-completion not working issue

### DIFF
--- a/docs/changelog-fragments.d/279.bugfix.md
+++ b/docs/changelog-fragments.d/279.bugfix.md
@@ -1,0 +1,4 @@
+```md
+Fix auto-completion and hover not working with execution environment issue.
+-- by {user}`ganeshrn`
+```

--- a/docs/changelog-fragments.d/279.bugfix.md
+++ b/docs/changelog-fragments.d/279.bugfix.md
@@ -1,4 +1,4 @@
 ```md
-Fix auto-completion and hover not working with execution environment issue.
--- by {user}`ganeshrn`
+Fix auto-completion and hover not working with execution environment issue. --
+by {user}`ganeshrn`
 ```

--- a/src/services/docsLibrary.ts
+++ b/src/services/docsLibrary.ts
@@ -37,7 +37,8 @@ export class DocsLibrary {
       const ansibleConfig = await this.context.ansibleConfig;
       if (settings.executionEnvironment.enabled) {
         // ensure plugin/module cache is established
-        await this.context.executionEnvironment;
+        const executionEnvironment = await this.context.executionEnvironment;
+        await executionEnvironment.fetchPluginDocs(ansibleConfig);
       }
       for (const modulesPath of ansibleConfig.module_locations) {
         (await findDocumentation(modulesPath, "builtin")).forEach((doc) => {

--- a/src/services/executionEnvironment.ts
+++ b/src/services/executionEnvironment.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { URI } from "vscode-uri";
 import { Connection } from "vscode-languageserver";
 import { v4 as uuidv4 } from "uuid";
+import { AnsibleConfig } from "./ansibleConfig";
 import { ImagePuller } from "../utils/imagePuller";
 import { asyncExec } from "../utils/misc";
 import { WorkspaceFolderContext } from "./workspaceManager";
@@ -82,7 +83,6 @@ export class ExecutionEnvironment {
         );
         return;
       }
-      await this.fetchPluginDocs();
     } catch (error) {
       if (error instanceof Error) {
         this.connection.window.showErrorMessage(error.message);
@@ -94,8 +94,7 @@ export class ExecutionEnvironment {
     }
   }
 
-  async fetchPluginDocs(): Promise<void> {
-    const ansibleConfig = await this.context.ansibleConfig;
+  async fetchPluginDocs(ansibleConfig: AnsibleConfig): Promise<void> {
     const containerName = `${this._container_image.replace(
       /[^a-z0-9]/gi,
       "_"


### PR DESCRIPTION
*  Currently fetch plugin from EE requires
   ansibleConfig service to be invoked to identify
   the path within EE that contains ansible plugins

*  Also docLibrary service invokes ansibleConfig
   service thus duplicating the call

*  The PR refactors the code to invoke fetching
   EE plugin docs from within docsLibrary service
   and thus avoiding multiple async invocation of
   ansibleConfig service