### PR TITLE
fix: add insertTextFormat to completionItem

### DIFF
--- a/docs/changelog-fragments.d/285.bugfix.md
+++ b/docs/changelog-fragments.d/285.bugfix.md
@@ -1,1 +1,2 @@
-Fixed indentation issue which resolving auto-completion items to support editors like vim and neovim -- by {user}`yaegassy`
+Fixed indentation issue which resolving auto-completion items to support editors
+like vim and neovim -- by {user}`yaegassy`

--- a/docs/changelog-fragments.d/285.bugfix.md
+++ b/docs/changelog-fragments.d/285.bugfix.md
@@ -1,2 +1,1 @@
-Fixed indentation issue which resolving auto-completion items to support editors
-like vim and neovim -- by {user}`yaegassy`
+Fixed indentation issue while resolving auto-completion items to support editors like vim and neovim -- by {user}`yaegassy`

--- a/docs/changelog-fragments.d/285.bugfix.md
+++ b/docs/changelog-fragments.d/285.bugfix.md
@@ -1,1 +1,2 @@
-Fixed indentation issue while resolving auto-completion items to support editors like vim and neovim -- by {user}`yaegassy`
+Fixed indentation issue while resolving auto-completion items to support editors
+like vim and neovim -- by {user}`yaegassy`

--- a/docs/changelog-fragments.d/285.bugfix.md
+++ b/docs/changelog-fragments.d/285.bugfix.md
@@ -1,0 +1,1 @@
+Fixed indentation issue which resolving auto-completion items to support editors like vim and neovim -- by {user}`yaegassy`

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -2,6 +2,7 @@ import { EOL } from "os";
 import {
   CompletionItem,
   CompletionItemKind,
+  InsertTextFormat,
   MarkupContent,
   Range,
   TextEdit,
@@ -368,8 +369,10 @@ export async function doCompletionResolve(
 
       if (completionItem.textEdit) {
         completionItem.textEdit.newText = insertText;
+        completionItem.insertTextFormat = InsertTextFormat.Snippet;
       } else {
         completionItem.insertText = insertText;
+        completionItem.insertTextFormat = InsertTextFormat.PlainText;
       }
 
       completionItem.documentation = formatModule(


### PR DESCRIPTION
## Description

There is an environment where indentation does not work correctly in `completionItem/resolve`.

It seems to behave correctly in VSCode, but when I tried it in a Vim/Neovim environment, I found a problem. Perhaps the situation is also a problem with other editors and IDEs.

In the case of "TextEdit", the fix was to set the "snippet" format with `insertTextFormat`.

## Before

**[NG] DEMO (mp4)**:

https://user-images.githubusercontent.com/188642/161216267-7c243248-a1e3-44b2-b6fc-ac0bc0bc6da1.mp4

## After

**[OK] DEMO (mp4)**:

https://user-images.githubusercontent.com/188642/161245925-6a16c84c-f2f2-4796-b4cc-4925ad95ed80.mp4

