### PR TITLE
Fix globby import pruned by webpack

### DIFF
--- a/src/utils/docsFinder.ts
+++ b/src/utils/docsFinder.ts
@@ -114,9 +114,13 @@ export async function findPluginRouting(
 }
 
 async function getGlobby() {
-  return (
-    await (Function('return import("globby")')() as Promise<
+  let globby: typeof import("globby");
+  try {
+    globby = await import("globby");
+  } catch (error) {
+    globby = await (Function('return import("globby")')() as Promise<
       typeof import("globby")
-    >)
-  ).globby;
+    >);
+  }
+  return globby.globby;
 }


### PR DESCRIPTION
This implements a workaround for globby import being pruned by webpack and subsequently failing client-side.
Fixes #290 