### PR TITLE
Fix auto-completion for modules when documentation is not displayed

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -112,6 +112,7 @@ Nalawade
 Tomasz
 dbaeumer
 esbenp
+fredericgiquel
 ganeshrn
 hbenl
 kimbernator

--- a/docs/changelog-fragments.d/329.bugfix.md
+++ b/docs/changelog-fragments.d/329.bugfix.md
@@ -1,1 +1,2 @@
-Fix auto-completion for modules when documentation is not displayed -- by {user}`fredericgiquel`
+Fix auto-completion for modules when documentation is not displayed -- by
+{user}`fredericgiquel`

--- a/docs/changelog-fragments.d/329.bugfix.md
+++ b/docs/changelog-fragments.d/329.bugfix.md
@@ -1,0 +1,1 @@
+Fix auto-completion for modules when documentation is not displayed -- by {user}`fredericgiquel`

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -149,6 +149,13 @@ export async function doCompletion(
                 kind = CompletionItemKind.Class;
               }
               const [namespace, collection, name] = moduleFqcn.split(".");
+              const insertName = useFqcn ? moduleFqcn : name;
+              const insertText = cursorAtEndOfLine
+                ? `${insertName}:${resolveSuffix(
+                    "dict", // since a module is always a dictionary
+                    cursorAtFirstElementOfList
+                  )}`
+                : insertName;
               return {
                 label: useFqcn ? moduleFqcn : name,
                 kind: kind,
@@ -166,7 +173,10 @@ export async function doCompletion(
                   atEndOfLine: cursorAtEndOfLine,
                   firstElementOfList: cursorAtFirstElementOfList,
                 },
-                textEdit: textEdit,
+                textEdit: {
+                  ...textEdit,
+                  newText: insertText,
+                },
               };
             }
           );

--- a/test/providers/completionProvider.test.ts
+++ b/test/providers/completionProvider.test.ts
@@ -47,8 +47,12 @@ function testPlayKeywords(
       } else {
         if (!filteredCompletion[0].item) {
           expect(filteredCompletion[0].label).be.equal(completion);
+          expect(filteredCompletion[0].textEdit.newText).be.equal(completion);
         } else {
           expect(filteredCompletion[0].item.label).to.be.equal(completion);
+          expect(filteredCompletion[0].item.textEdit.newText).to.be.equal(
+            completion
+          );
         }
       }
     });
@@ -88,8 +92,12 @@ function testRoleKeywords(
       } else {
         if (!filteredCompletion[0].item) {
           expect(filteredCompletion[0].label).be.equal(completion);
+          expect(filteredCompletion[0].textEdit.newText).be.equal(completion);
         } else {
           expect(filteredCompletion[0].item.label).to.be.equal(completion);
+          expect(filteredCompletion[0].item.textEdit.newText).to.be.equal(
+            completion
+          );
         }
       }
     });
@@ -129,8 +137,12 @@ function testBlockKeywords(
       } else {
         if (!filteredCompletion[0].item) {
           expect(filteredCompletion[0].label).be.equal(completion);
+          expect(filteredCompletion[0].textEdit.newText).be.equal(completion);
         } else {
           expect(filteredCompletion[0].item.label).to.be.equal(completion);
+          expect(filteredCompletion[0].item.textEdit.newText).to.be.equal(
+            completion
+          );
         }
       }
     });
@@ -170,8 +182,12 @@ function testTaskKeywords(
       } else {
         if (!filteredCompletion[0].item) {
           expect(filteredCompletion[0].label).be.equal(completion);
+          expect(filteredCompletion[0].textEdit.newText).be.equal(completion);
         } else {
           expect(filteredCompletion[0].item.label).to.be.equal(completion);
+          expect(filteredCompletion[0].item.textEdit.newText).to.be.equal(
+            completion
+          );
         }
       }
     });
@@ -241,8 +257,12 @@ function testModuleNames(
       } else {
         if (!filteredCompletion[0].item) {
           expect(filteredCompletion[0].label).to.contain(completion);
+          expect(filteredCompletion[0].textEdit.newText).to.contain(completion);
         } else {
           expect(filteredCompletion[0].item.label).to.contain(completion);
+          expect(filteredCompletion[0].item.textEdit.newText).to.contain(
+            completion
+          );
         }
       }
     });
@@ -306,8 +326,12 @@ function testModuleOptions(
       } else {
         if (!filteredCompletion[0].item) {
           expect(filteredCompletion[0].label).be.equal(completion);
+          expect(filteredCompletion[0].textEdit.newText).be.equal(completion);
         } else {
           expect(filteredCompletion[0].item.label).to.be.equal(completion);
+          expect(filteredCompletion[0].item.textEdit.newText).be.equal(
+            completion
+          );
         }
       }
     });
@@ -355,7 +379,7 @@ function testModuleOptionsValues(
     it(`should provide completion for ${name}`, async function () {
       const actualCompletion = await doCompletion(textDoc, position, context);
 
-      const filteredCompletion = smartFilter(
+      const labelCompletion = smartFilter(
         actualCompletion,
         triggerCharacter
       ).map((completion) => {
@@ -367,9 +391,26 @@ function testModuleOptionsValues(
       });
 
       if (!completion) {
-        expect(filteredCompletion.length).be.equal(0);
+        expect(labelCompletion.length).be.equal(0);
       } else {
-        expect(filteredCompletion).be.deep.equal(completion);
+        expect(labelCompletion).be.deep.equal(completion);
+      }
+
+      const newTextCompletion = smartFilter(
+        actualCompletion,
+        triggerCharacter
+      ).map((completion) => {
+        if (!completion.item) {
+          return completion.textEdit.newText;
+        } else {
+          return completion.item.textEdit.newText;
+        }
+      });
+
+      if (!completion) {
+        expect(newTextCompletion.length).be.equal(0);
+      } else {
+        expect(newTextCompletion).be.deep.equal(completion);
       }
     });
   });
@@ -429,8 +470,12 @@ function testModuleNamesWithoutFQCN(
       } else {
         if (!filteredCompletion[0].item) {
           expect(filteredCompletion[0].label).be.equal(completion);
+          expect(filteredCompletion[0].textEdit.newText).be.equal(completion);
         } else {
           expect(filteredCompletion[0].item.label).to.be.equal(completion);
+          expect(filteredCompletion[0].item.textEdit.newText).to.be.equal(
+            completion
+          );
         }
       }
     });


### PR DESCRIPTION
Possible solution for https://github.com/ansible/ansible-language-server/issues/329

It fixes the bug both with VSCodium and Emacs.