### PR TITLE
add ee service plugin path logs

### DIFF
--- a/docs/changelog-fragments.d/331.misc.md
+++ b/docs/changelog-fragments.d/331.misc.md
@@ -1,2 +1,2 @@
-Added plugin path logs in executionEnvironment service to add information releated to copied plugins from within EE to local path.
--- by {user}`ganeshrn`
+Added plugin path logs in executionEnvironment service to add information
+releated to copied plugins from within EE to local path. -- by {user}`ganeshrn`

--- a/docs/changelog-fragments.d/331.misc.md
+++ b/docs/changelog-fragments.d/331.misc.md
@@ -1,2 +1,2 @@
 Added plugin path logs in executionEnvironment service to add information
-releated to copied plugins from within EE to local path. -- by {user}`ganeshrn`
+related to copied plugins from within EE to local path. -- by {user}`ganeshrn`

--- a/docs/changelog-fragments.d/331.misc.md
+++ b/docs/changelog-fragments.d/331.misc.md
@@ -1,2 +1,2 @@
-Added plugin path logs in executionEnvironment service to add information
+Added plugin path logs in execution environment service to add information
 related to copied plugins from within EE to local path. -- by {user}`ganeshrn`

--- a/docs/changelog-fragments.d/331.misc.md
+++ b/docs/changelog-fragments.d/331.misc.md
@@ -1,0 +1,2 @@
+Added plugin path logs in executionEnvironment service to add information releated to copied plugins from within EE to local path.
+-- by {user}`ganeshrn`

--- a/src/services/executionEnvironment.ts
+++ b/src/services/executionEnvironment.ts
@@ -116,6 +116,10 @@ export class ExecutionEnvironment {
           ansibleConfig.module_locations,
           hostCacheBasePath
         );
+
+        this.connection.console.log(
+          `Cached plugin paths: \n collections_paths: ${ansibleConfig.collections_paths} \n module_locations: ${ansibleConfig.module_locations}`
+        );
       } else {
         if (this.useProgressTracker) {
           progressTracker =
@@ -129,6 +133,9 @@ export class ExecutionEnvironment {
             true
           );
         }
+        this.connection.console.log(
+          `Identified plugin paths by AnsibleConfig service: \n collections_paths: ${ansibleConfig.collections_paths} \n module_locations: ${ansibleConfig.module_locations}`
+        );
         ansibleConfig.collections_paths = await this.copyPluginDocFiles(
           hostCacheBasePath,
           containerName,
@@ -164,6 +171,9 @@ export class ExecutionEnvironment {
           "/"
         );
       }
+      this.connection.console.log(
+        `Copied plugin paths by ExecutionEnvironment service: \n collections_paths: ${ansibleConfig.collections_paths} \n module_locations: ${ansibleConfig.module_locations}`
+      );
       // plugin cache successfully created
       fs.closeSync(
         fs.openSync(path.join(hostCacheBasePath, this.successFileMarker), "w+")


### PR DESCRIPTION
Add ee service plugin path logs to help debugging the collection and module path copied from within EE to local cache