### PR TITLE
Rename ci pipeline to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 ---
 # spell-checker:ignore fregante hexdigest vsoch ncipollo ghpnr
-name: CI
+name: release
 
 on:
-  pull_request:
-  push:
-    branches: # any integration branch but not tag
-      - "main"
   workflow_dispatch:
     inputs:
       release-version:


### PR DESCRIPTION
Rename old "ci" pipeline to "release" and make it run only on
manual triggers, as we use "tox" one for normal testing.

Follow-ups will start cleaning the file and remove the testing bits.
