### PR TITLE
Add check to validate mount path before passing it as an arg in EE

### DIFF
--- a/docs/changelog-fragments.d/345.bugfix.md
+++ b/docs/changelog-fragments.d/345.bugfix.md
@@ -1,0 +1,2 @@
+Added validation of mount path before passing it as an argument to wrap the
+commands in execution environment -- by {user}`priyamsahoo`

--- a/src/services/executionEnvironment.ts
+++ b/src/services/executionEnvironment.ts
@@ -214,6 +214,14 @@ export class ExecutionEnvironment {
     );
 
     for (const mountPath of mountPaths || []) {
+      // push to array only if mount path is valid
+      if (mountPath === "" || !fs.existsSync(mountPath)) {
+        this.connection.console.error(
+          `Volume mount source path '${mountPath}' does not exist. Ignoring this volume mount entry.`
+        );
+        continue;
+      }
+
       const volumeMountPath = `${mountPath}:${mountPath}`;
       if (containerCommand.includes(volumeMountPath)) {
         continue;


### PR DESCRIPTION
The PR has an implementation to check if the mount path is valid or not before wrapping it in the ee commands.