### PR TITLE
docs: add note on standalone usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ You may also open the implementation of any module using the standard _Go to
 Definition_ operation, for instance, by clicking on the module name while
 holding `ctrl`/`cmd`.
 
+## Standalone Usage
+
+For standalone usage with a language server client, Ansible language server can be installed from npm with the following command:
+
+```bash
+npm install -g @ansible/ansible-language-server
+```
+
 ## Language Server Settings
 
 For details on settings, their descriptions and their default values refer to


### PR DESCRIPTION
This pull request adds a note on standalone usage. I'm not sure if there's that much to explain, but if there are further instructions that you think should be included, let me know! I placed it in the README above the language server settings heading since that's related.

Clsoes #188.