### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,21 @@ Do *NOT* manually add changelog entries here! This file is updated by
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v0.8.0
+
+### Minor Changes
+
+- Add settings for completion (#348) @fredericgiquel
+
+### Bugfixes
+
+- Fix documentation version reading (#363) @ssbarnea
+- docs: add note on standalone usage (#347) @mtoohey31
+- Refactor npm package (#356) @ssbarnea
+- Bump ansible-lint from 6.2.2 to 6.3.0 (#346)
+- Add check to validate mount path before passing it as an arg in EE (#345)
+  @priyamsahoo
+
 ## v0.7.2 (2022-05-24)
 
 ### Bugfixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ansible/ansible-language-server",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ansible/ansible-language-server",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.18",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Ansible",
   "description": "Ansible language server",
   "license": "MIT",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "contributors": [
     {
       "name": "Tomasz Maciążek",


### PR DESCRIPTION
## v0.8.0

### Minor Changes

- Add settings for completion (#348) @fredericgiquel

### Bugfixes

- Fix documentation version reading (#363) @ssbarnea
- docs: add note on standalone usage (#347) @mtoohey31
- Refactor npm package (#356) @ssbarnea
- Bump ansible-lint from 6.2.2 to 6.3.0 (#346)
- Add check to validate mount path before passing it as an arg in EE (#345) @priyamsahoo
