### PR TITLE
Add --version flag for ansible-language-server

### DIFF
--- a/bin/ansible-language-server
+++ b/bin/ansible-language-server
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
 
-require("../out/server/src/server.js");
+if (process.argv.includes("--version")) {
+  const pkgJSON = require("../package.json");
+  console.log(`${pkgJSON["version"]}`);
+} else {
+  require("../out/server/src/server.js");
+}

--- a/test/utils/runCommand.test.ts
+++ b/test/utils/runCommand.test.ts
@@ -3,9 +3,26 @@ import { AssertionError, expect } from "chai";
 import { WorkspaceManager } from "../../src/services/workspaceManager";
 import { createConnection } from "vscode-languageserver/node";
 import { getDoc } from "../helper";
+import * as path from "path";
 
 describe("commandRunner", () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const pkgJSON = require(path.resolve(__dirname, "..", "..", "package.json"));
+
   const tests = [
+    {
+      args: [
+        path.join(
+          path.resolve(__dirname, "..", ".."),
+          "bin",
+          "ansible-language-server"
+        ),
+        "--version",
+      ],
+      rc: 0,
+      stdout: `${pkgJSON["version"]}`,
+      stderr: "",
+    },
     {
       args: ["ansible-config", "dump"],
       rc: 0,


### PR DESCRIPTION
I thought it would be useful to have the `--version` flag option in cli, so I added it.

**After**:

```
$ ./bin/ansible-language-server --version
0.8.0
```