### PR TITLE
fix(completion): handling of cases where lsp clients do not send required settings

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -63,14 +63,14 @@ export async function doCompletion(
   preparedText = insert(preparedText, offset, "_:");
   const yamlDocs = parseAllDocuments(preparedText);
 
-  const useFqcn = (await context.documentSettings.get(document.uri)).ansible
-    .useFullyQualifiedCollectionNames;
-  const provideRedirectModulesCompletion = (
-    await context.documentSettings.get(document.uri)
-  ).completion.provideRedirectModules;
-  const provideModuleOptionAliasesCompletion = (
-    await context.documentSettings.get(document.uri)
-  ).completion.provideModuleOptionAliases;
+  const extensionSettings = await context.documentSettings.get(document.uri);
+
+  const useFqcn =
+    extensionSettings.ansible?.useFullyQualifiedCollectionNames ?? true;
+  const provideRedirectModulesCompletion =
+    extensionSettings.completion?.provideRedirectModules ?? true;
+  const provideModuleOptionAliasesCompletion =
+    extensionSettings.completion?.provideModuleOptionAliases ?? true;
 
   // We need inclusive matching, since cursor position is the position of the character right after it
   // NOTE: Might no longer be required due to the hack above


### PR DESCRIPTION
Close https://github.com/ansible/ansible-language-server/issues/391

---

There are some LSP clients that send only minimal settings to make the Language Server work. Or some LSP clients may not be able to keep up with updates of additional Language Server settings.

- For example: nvim-lspconfig
  - <https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/ansiblels.lua#L13-L29>

To solve such cases, we have modified to set the value in the Language Server in the case of undefined.

