### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ Do *NOT* manually add changelog entries here! This file is updated by
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v0.10.0
+
+### Minor Changes
+
+- Expose metadata about environment to the client (#413) @priyamsahoo
+
+### Bugfixes
+
+- Fallback to default value if setting is not provided by client (#409)
+  @fredericgiquel
+- Bump ansible-compat from 2.1.0 to 2.2.0 in /.config (#408)
+- Add handling of cases where lsp clients do not send required settings (#405)
+  @yaegassy
+
 ## v0.9.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ansible/ansible-language-server",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ansible/ansible-language-server",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.18",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Ansible",
   "description": "Ansible language server",
   "license": "MIT",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "contributors": [
     {
       "name": "Tomasz Maciążek",


### PR DESCRIPTION
## v0.10.0

### Minor Changes

- Expose metadata about environment to the client (#413) @priyamsahoo

### Bugfixes

- Fallback to default value if setting is not provided by client (#409) @fredericgiquel
- Bump ansible-compat from 2.1.0 to 2.2.0 in /.config (#408)
- Add handling of cases where lsp clients do not send required settings (#405) @yaegassy
