### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ Do *NOT* manually add changelog entries here! This file is updated by
 - Add handling of cases where lsp clients do not send required settings (#405)
   @yaegassy
 
+## v0.10.0
+
+### Minor Changes
+
+- Expose metadata about environment to the client (#413) @priyamsahoo
+
+### Bugfixes
+
+- Fallback to default value if setting is not provided by client (#409)
+  @fredericgiquel
+- Bump ansible-compat from 2.1.0 to 2.2.0 in /.config (#408)
+- Add handling of cases where lsp clients do not send required settings (#405)
+  @yaegassy
+
 ## v0.9.0
 
 ### Minor Changes


### PR DESCRIPTION
## v0.10.0

### Minor Changes

- Expose metadata about environment to the client (#413) @priyamsahoo

### Bugfixes

- Fallback to default value if setting is not provided by client (#409) @fredericgiquel
- Bump ansible-compat from 2.1.0 to 2.2.0 in /.config (#408)
- Add handling of cases where lsp clients do not send required settings (#405) @yaegassy
