### PR TITLE
Update GHA release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,10 +1,8 @@
 ---
 # This workflow is generating a pull request with updated version and changelog
-name: release
+name: prepare-release
 "on":
   workflow_dispatch:
-  release:
-    types: [published]
 
 permissions: write-all
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@
 name: publish
 "on":
   workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   npmjs:


### PR DESCRIPTION
- ensure publish is called when we release from web interface
- rename release to prepare-release to make it less confusing
