### PR TITLE
Replace `python` with `python3` in command execution

### DIFF
--- a/src/utils/getAnsibleMetaData.ts
+++ b/src/utils/getAnsibleMetaData.ts
@@ -109,7 +109,7 @@ async function getPythonInfo() {
   const pythonInfo = {};
 
   const pythonVersionResult = await getResultsThroughCommandRunner(
-    "python",
+    "python3",
     "--version"
   );
   if (pythonVersionResult === undefined) {

--- a/test/fixtures/diagnostics/lint_errors.yml
+++ b/test/fixtures/diagnostics/lint_errors.yml
@@ -12,5 +12,5 @@
         data: 10101
       when: MY_VAR != ''
 
-    - name: this would typically fire deprecated-command-syntax
+    - name: This would typically fire deprecated-command-syntax
       command: warn=no chmod 644 X

--- a/test/utils/getAnsibleMetaData.test.ts
+++ b/test/utils/getAnsibleMetaData.test.ts
@@ -79,7 +79,7 @@ function testCommands() {
         result: "configured module search path",
       },
       {
-        args: ["python", "--version"],
+        args: ["python3", "--version"],
         result: "Python",
       },
       {


### PR DESCRIPTION
This PR replaces `python` with `python3` in command execution while collecting ansible metadata.
Related: #428, https://github.com/ansible/vscode-ansible/issues/607.

Additional:
Updates ansible-lint test for linting task names starting with lowercase letters.