### PR TITLE
Fix missing ansible-lint warning

### DIFF
--- a/src/utils/getAnsibleMetaData.ts
+++ b/src/utils/getAnsibleMetaData.ts
@@ -51,9 +51,9 @@ export async function getResultsThroughCommandRunner(cmd, arg) {
 
     if (result.stderr) {
       console.log(
-        `cmd '${cmd} ${arg}' has the following error: ${result.stderr}`,
+        `cmd '${cmd} ${arg}' has the following error/warning: ${result.stderr}`
       );
-      return undefined;
+      return result;
     }
   } catch (error) {
     console.log(

--- a/src/utils/getAnsibleMetaData.ts
+++ b/src/utils/getAnsibleMetaData.ts
@@ -51,7 +51,7 @@ export async function getResultsThroughCommandRunner(cmd, arg) {
 
     if (result.stderr) {
       console.log(
-        `cmd '${cmd} ${arg}' has the following error/warning: ${result.stderr}`
+        `cmd '${cmd} ${arg}' has the following error/warning: ${result.stderr}`,
       );
       return result;
     }


### PR DESCRIPTION
The PR fixes the missing ansible-lint warning from the ansible meta-data displayed on hovering over the Ansible statusbar item.

Fixes: https://github.com/ansible/vscode-ansible/issues/607