### PR TITLE
Fix 'handlers' keyword syntax highlighting and auto-completion

### DIFF
--- a/src/utils/ansible.ts
+++ b/src/utils/ansible.ts
@@ -703,7 +703,7 @@ taskKeywords.set(
   `Allows handlers to listen on topics that can group multiple handlers.
 
   NOTE:
-  Applies only to handlers. See [listen](https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html#handlers-running-when-notified)`
+  Applies only to handlers. See [listen](https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html#handlers-running-when-notified)`,
 );
 
 export const playExclusiveKeywords = new Map(

--- a/src/utils/ansible.ts
+++ b/src/utils/ansible.ts
@@ -698,6 +698,14 @@ taskKeywords.set(
   "Conditional expression, determines if an iteration of a task is run or not.",
 );
 
+taskKeywords.set(
+  "listen",
+  `Allows handlers to listen on topics that can group multiple handlers.
+
+  NOTE:
+  Applies only to handlers. See [listen](https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html#handlers-running-when-notified)`
+);
+
 export const playExclusiveKeywords = new Map(
   [...playKeywords].filter(
     ([k]) =>

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -207,7 +207,8 @@ export function getPathAtOffset(
   return null;
 }
 
-export const tasksKey = /^(tasks|pre_tasks|post_tasks|block|rescue|always)$/;
+export const tasksKey =
+  /^(tasks|pre_tasks|post_tasks|block|rescue|always|handlers)$/;
 
 /**
  * Determines whether the path points at a parameter key of an Ansible task.


### PR DESCRIPTION
The PR: 
- adds `handlers` to the task key regex, so that appropriate syntax highlighting and auto-completion work for it. (Fixes: https://github.com/ansible/vscode-ansible/issues/628)
- adds `listen` under the task keywords with a note that it is to be used only under `handlers`. An ansible-lint rule shall be written to check the presence of `listen` under `tasks`. (Fixes: https://github.com/ansible/ansible-language-server/issues/162)

Fixes: #162