### PR TITLE
Release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ Do *NOT* manually add changelog entries here! This file is updated by
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v0.10.2
+
+### Bugfixes
+
+- Fix 'handlers' keyword syntax highlighting and auto-completion (#440)
+  @priyamsahoo
+- Fix missing ansible-lint warning (#438) @priyamsahoo
+- Replace `python` with `python3` in command execution (#430) @priyamsahoo
+
 ## v0.10.1
 
 ### Bugfixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ansible/ansible-language-server",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ansible/ansible-language-server",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.18",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Ansible",
   "description": "Ansible language server",
   "license": "MIT",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "contributors": [
     {
       "name": "Tomasz Maciążek",


### PR DESCRIPTION
## v0.10.2

### Bugfixes

- Fix 'handlers' keyword syntax highlighting and auto-completion (#440) @priyamsahoo
- Fix missing ansible-lint warning (#438) @priyamsahoo
- Replace `python` with `python3` in command execution (#430) @priyamsahoo
