### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ Do *NOT* manually add changelog entries here! This file is updated by
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v1.0.1
+
+### Bugfixes
+
+- Add documentation link for violated ansible-lint rules (#461) @priyamsahoo
+- Support for FQCN with more than 3 elements (#449) @fredericgiquel
+- Replace `which` with `command -v` (#463) @priyamsahoo
+
 ## v1.0.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ansible/ansible-language-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ansible/ansible-language-server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.18",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Ansible",
   "description": "Ansible language server",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "contributors": [
     {
       "name": "Tomasz Maciążek",


### PR DESCRIPTION
## v1.0.1

### Bugfixes

- Add documentation link for violated ansible-lint rules (#461) @priyamsahoo
- Support for FQCN with more than 3 elements (#449) @fredericgiquel
- Replace `which` with `command -v` (#463) @priyamsahoo
