### PR TITLE
Avoid parsing ansible-lint config file

### DIFF
--- a/src/interfaces/ansibleLintConfig.ts
+++ b/src/interfaces/ansibleLintConfig.ts
@@ -1,3 +1,0 @@
-export interface IAnsibleLintConfig {
-  warnList: Set<string>;
-}

--- a/src/services/workspaceManager.ts
+++ b/src/services/workspaceManager.ts
@@ -168,7 +168,6 @@ export class WorkspaceFolderContext {
     params: DidChangeWatchedFilesParams,
   ): void {
     this.documentMetadata.handleWatchedDocumentChange(params);
-    this.ansibleLint.handleWatchedDocumentChange(params);
     for (const fileEvent of params.changes) {
       if (fileEvent.uri.startsWith(this.workspaceFolder.uri)) {
         // in case the configuration changes for this folder, we should


### PR DESCRIPTION
The code change incorporates the latest changes from ansible-lint, which sends 'level' as a key in the JSON output. The 'level' key tells the level of rule violation, i.e., error or warning. 

In this way, ALS leverages this information and segregates errors and warnings.
Enhancement of: https://github.com/ansible/ansible-language-server/pull/474.

***Note: This feature works only with ansible-lint `v6.8.6` or above.***