### PR TITLE
Bump ansible-lint version from 6.8.4 to 6.8.6

### DIFF
--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 ansible-compat==2.2.3
 ansible-core==2.13.5
-ansible-lint==6.8.4
+ansible-lint==6.8.6
 ansible-pygments==0.1.1
 astroid==2.11.6
 attrs==21.4.0

--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -1,5 +1,5 @@
 alabaster==0.7.12
-ansible-compat==2.2.3
+ansible-compat==2.2.4
 ansible-core==2.13.5
 ansible-lint==6.8.6
 ansible-pygments==0.1.1


### PR DESCRIPTION
Additionally, updates the ansible-compat from version 2.2.3 to 2.2.4 as part of the requirement.