### PR TITLE
Use ghcr.io instead of quay.io as default registry

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -117,9 +117,9 @@ tasks:
     deps:
       - setup
     cmds:
-      - "{{.ENGINE}} pull quay.io/ansible/creator-ee:latest"
+      - "{{.ENGINE}} pull ghcr.io/ansible/creator-ee:latest"
       # Tests that container engine is functional and that we have the image:
-      - "{{.ENGINE}} run -i quay.io/ansible/creator-ee:latest ansible-lint --version"
+      - "{{.ENGINE}} run -i ghcr.io/ansible/creator-ee:latest ansible-lint --version"
       - >
         source $VIRTUAL_ENV/bin/activate &&
         command -v ansible-lint &&

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -37,7 +37,7 @@ _default value:
 - **ansible.executionEnvironment.image**:
 Name of the execution environment to be used \
 _default value:
-`quay.io/ansible/creator-ee:latest`_
+`ghcr.io/ansible/creator-ee:latest`_
 
 - **ansible.executionEnvironment.pull.policy**:
 Image pull policy to be used. Valid values are &#x27;always&#x27;, &#x27;missing&#x27;, &#x27;never&#x27; and &#x27;tag&#x27;. always will always pull the image when extension is activated or reloaded. &#x27;missing&#x27; will pull if not locally available. &#x27;never&#x27; will never pull the image and &#x27;tag&#x27; will always pull if the image tag is &#x27;latest&#x27;, otherwise pull if not locally available. \

--- a/src/services/settingsManager.ts
+++ b/src/services/settingsManager.ts
@@ -52,7 +52,7 @@ export class SettingsManager {
         description: "Toggle usage of an execution environment",
       },
       image: {
-        default: "quay.io/ansible/creator-ee:latest",
+        default: "ghcr.io/ansible/creator-ee:latest",
         description: "Name of the execution environment to be used",
       },
       pull: {

--- a/test/utils/getAnsibleMetaData.test.ts
+++ b/test/utils/getAnsibleMetaData.test.ts
@@ -59,7 +59,7 @@ function getAnsibleLintTestInfo() {
 function getExecutionEnvironmentTestInfo() {
   const eeInfo = {};
   eeInfo["container engine"] = ["docker", "podman"];
-  eeInfo["container image"] = "quay.io/";
+  eeInfo["container image"] = "ghcr.io/";
   eeInfo["container volume mounts"] = [
     {
       src: "/fixtures/common/collections",

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -5,7 +5,7 @@
 # (cspell: disable-next-line)
 set -euo pipefail
 
-IMAGE=quay.io/ansible/creator-ee:latest
+IMAGE=ghcr.io/ansible/creator-ee:latest
 PIP_LOG_FILE=out/log/pip.log
 HOSTNAME="${HOSTNAME:-localhost}"
 ERR=0


### PR DESCRIPTION
As most of our runs are from inside Azure, we prefer using ghcr.io
as primary registry. That affects only default settings.
