### PR TITLE
Improve testing output

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,5 +1,6 @@
 require:
   - ts-node/register
   - test/rootMochaHooks.ts
+reporter: tap # more flat, also the only one that mentions totals for found, skipped and passed
 spec: './test/**/*.ts'
 timeout: 60000 # same as 60 seconds. This done to ensure that we have sufficient time to run tests on the CI as each test involves loading yaml files and docs library for ansible.

--- a/test/rootMochaHooks.ts
+++ b/test/rootMochaHooks.ts
@@ -1,4 +1,7 @@
+import * as chai from "chai";
 import { ConsoleOutput } from "./consoleOutput";
+
+chai.config.truncateThreshold = 0; // disable truncating
 
 export const mochaHooks = (): Mocha.RootHookObject => {
   const consoleOutput = new ConsoleOutput();


### PR DESCRIPTION
- disable chai truncation (ellipsis)
- use tap reporter instead of default one because it includes total
  number of passed and failed tests and is flatter
