### PR TITLE
Remove als acronym from docs website title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,7 @@ html_context = {
 html_title = f"{project} Documentation"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-# html_short_title = "ALS Documentation"
+# html_short_title = 
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,7 @@ html_context = {
 html_title = f"{project} Documentation"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-# html_short_title = 
+# html_short_title =
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,7 @@ html_context = {
 html_title = f"{project} Documentation"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-html_short_title = "ALS Documentation"
+# html_short_title = "ALS Documentation"
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
ALS is an unfortunate acronym choice as it is also the acronym for a fatal disease (Lou Gehrig's disease).

Local tests shows this doesn't have to be abbreviated as the short title, this this PR.