### PR TITLE
Make community projects use Ansible teal

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ html_show_sphinx = True
 html_theme_options = {
     "collapse_navigation": False,
     "analytics_id": "",
-    "style_nav_header_background": "#ff5850",  # #5bbdbf
+    "style_nav_header_background": "#5bbdbf",
     "style_external_links": True,
     "canonical_url": f"https://{github_repo_name}.readthedocs.io/en/latest/",
     "vcs_pageview_mode": "edit",


### PR DESCRIPTION
Ansible documentation reserves red as a color scheme for official product documentation. At this point, I think only the ansible-controller docs should use red. This PR converts the color scheme back to Ansible teal, denoting community docs.

This is in preparation to link these docs from docs.ansible.com.