### PR TITLE
Add note about task vs go-task

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,11 +6,13 @@ To contribute, you'll need to:
 
 2. Create a branch and push your changes there.
 
-3. Run [task] and ensure it does pass.
+3. Install and run [task] and ensure it does pass.
 
 4. Send it to us as a PR.
 
 5. Iterate on your PR, incorporating the requested improvements and
    participating in the discussions.
+
+**_NOTE:_** On some operating systems, ``task`` may be another command, such as ``go-task``.
 
 [task]: https://taskfile.dev/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,6 +13,7 @@ To contribute, you'll need to:
 5. Iterate on your PR, incorporating the requested improvements and
    participating in the discussions.
 
-**_NOTE:_** On some operating systems, ``task`` may be another command, such as ``go-task``.
+**_NOTE:_** On some operating systems, `task` may be another command, such as
+`go-task`.
 
 [task]: https://taskfile.dev/


### PR DESCRIPTION
This is a bit of a nit, but installing this on Fedora, I found out the install is for ``go-task``. So figured I'd add a note about it and about installing task etc.

...could just be my own goober slowness in reading the contributing guidelines so feel free to close w/o merge if you thing this is easy stuff.