### PR TITLE
Release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ Do *NOT* manually add changelog entries here! This file is updated by
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v1.0.3
+
+### Bugfixes
+
+- Correct container name (#515) @ssbarnea
+- Add note about task vs go-task (#509) @samccann
+- Remove als acronym from docs website title (#507) @samccann
+- Isolate container caching from others (#492) @ssbarnea
+- Update docs url (#494) @ssbarnea
+- Make node 14 minimal version required (#491) @ssbarnea
+- Use ghcr.io instead of quay.io as default registry (#489) @ssbarnea
+
 ## v1.0.2
 
 ### Bugfixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ansible/ansible-language-server",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ansible/ansible-language-server",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.18",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Ansible",
   "description": "Ansible language server",
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "contributors": [
     {
       "name": "Tomasz Maciążek",


### PR DESCRIPTION
## v1.0.3

### Bugfixes

- Correct container name (#515) @ssbarnea
- Add note about task vs go-task (#509) @samccann
- Remove als acronym from docs website title (#507) @samccann
- Isolate container caching from others (#492) @ssbarnea
- Update docs url (#494) @ssbarnea
- Make node 14 minimal version required (#491) @ssbarnea
- Use ghcr.io instead of quay.io as default registry (#489) @ssbarnea
