### PR TITLE
Use antsibull-docs-ts to render semantic markup

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -17,6 +17,7 @@ YOLO
 alphanums
 ansible
 ansiblefest
+antsibull
 apidoc
 autocrlf
 autofix

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.20",
+        "antsibull-docs": "^1.0.0",
         "glob": "^9.3.2",
         "ini": "^4.0.0",
         "lodash": "^4.17.21",
@@ -1477,6 +1478,11 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/antsibull-docs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/antsibull-docs/-/antsibull-docs-1.0.0.tgz",
+      "integrity": "sha512-OqrXCQkKeqTTuFBmQc9RJnXPcjUtRnMq0rfmT3zlp6UHJWTwq1SLffwOEw1I5jC7FNLMoabUjPb8wxCNB3RaZw=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -8297,6 +8303,11 @@
       "requires": {
         "color-convert": "^2.0.1"
       }
+    },
+    "antsibull-docs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/antsibull-docs/-/antsibull-docs-1.0.0.tgz",
+      "integrity": "sha512-OqrXCQkKeqTTuFBmQc9RJnXPcjUtRnMq0rfmT3zlp6UHJWTwq1SLffwOEw1I5jC7FNLMoabUjPb8wxCNB3RaZw=="
     },
     "anymatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   ],
   "dependencies": {
     "@flatten-js/interval-tree": "^1.0.20",
+    "antsibull-docs": "^1.0.0",
     "glob": "^9.3.2",
     "ini": "^4.0.0",
     "lodash": "^4.17.21",

--- a/src/utils/docsFormatter.ts
+++ b/src/utils/docsFormatter.ts
@@ -1,5 +1,6 @@
 import { format } from "util";
 import { MarkupContent, MarkupKind } from "vscode-languageserver";
+import { parse, toMD } from "antsibull-docs";
 import {
   IDescription,
   IModuleDocumentation,
@@ -135,16 +136,6 @@ export function getDetails(option: IOption): string | undefined {
 }
 
 // TODO: do something with links
-const macroPatterns = {
-  link: /L\((.*?),(.*?)\)/g,
-  url: /U\((.*?)\)/g,
-  reference: /R\((.*?),(.*?)\)/g,
-  module: /M\((.*?)\)/g,
-  monospace: /C\((.*?)\)/g,
-  italics: /I\((.*?)\)/g,
-  bold: /B\((.*?)\)/g,
-  hr: /\bHORIZONTALLINE\b/,
-};
 function replaceMacros(text: unknown): string {
   let safeText;
   if (typeof text === "string") {
@@ -152,13 +143,5 @@ function replaceMacros(text: unknown): string {
   } else {
     safeText = JSON.stringify(text);
   }
-  return safeText
-    .replace(macroPatterns.link, "[$1]($2)")
-    .replace(macroPatterns.url, "$1")
-    .replace(macroPatterns.reference, "[$1]($2)")
-    .replace(macroPatterns.module, "*`$1`*")
-    .replace(macroPatterns.monospace, "`$1`")
-    .replace(macroPatterns.italics, "_$1_")
-    .replace(macroPatterns.bold, "**$1**")
-    .replace(macroPatterns.hr, "<hr>");
+  return toMD(parse(safeText));
 }

--- a/test/providers/hoverProvider.test.ts
+++ b/test/providers/hoverProvider.test.ts
@@ -131,7 +131,7 @@ function testModuleNames(
     {
       word: "ansible.builtin.debug -> msg",
       position: { line: 5, character: 10 } as Position,
-      doc: "The customized message that is printed. If omitted, prints a generic message.",
+      doc: "The customized message that is printed\\. If omitted\\, prints a generic message\\.",
     },
   ];
 


### PR DESCRIPTION
Uses the TypeScript library [antsibull-docs](https://www.npmjs.com/package/antsibull-docs) (https://github.com/ansible-community/antsibull-docs-ts) to render Ansible markup, including the new semantic markup.

(I marked this as a draft since I want to wait a bit until antsibull-docs-ts reaches 1.0.0 before making this ready.)