### PR TITLE
Release v1.1.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,20 @@ Do *NOT* manually add changelog entries here! This file is updated by
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v1.1.0
+
+- Bump json5 from 2.2.1 to 2.2.3 (#539)
+
+### Minor Changes
+
+- Add variable auto-completion feature when cursor inside jinja inline brackets
+  (#552) @priyamsahoo
+
+### Bugfixes
+
+- Get module route for FQCN with more than 3 elements (#538) @fredericgiquel
+- Replace sphinx with mkdocs (#544) @ssbarnea
+
 ## v1.0.4
 
 ### Bugfixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ansible/ansible-language-server",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ansible/ansible-language-server",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.20",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Ansible",
   "description": "Ansible language server",
   "license": "MIT",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "contributors": [
     {
       "name": "Tomasz Maciążek",


### PR DESCRIPTION
## v1.1.0

- Bump json5 from 2.2.1 to 2.2.3 (#539)

### Minor Changes

- Add variable auto-completion feature when cursor inside jinja inline brackets (#552) @priyamsahoo

### Bugfixes

- Get module route for FQCN with more than 3 elements (#538) @fredericgiquel
- Replace sphinx with mkdocs (#544) @ssbarnea
