### PR TITLE
Avoid adding sys.path to collections path

### DIFF
--- a/src/services/ansibleConfig.ts
+++ b/src/services/ansibleConfig.ts
@@ -78,16 +78,6 @@ export class AnsibleConfig {
       );
 
       this._ansible_location = versionInfo["ansible python module location"];
-
-      // get Python sys.path
-      // this is needed to get the pre-installed collections to work
-      const pythonPathResult = await commandRunner.runCommand(
-        "python3",
-        ' -c "import sys; print(sys.path, end=\\"\\")"',
-      );
-      this._collection_paths.push(
-        ...parsePythonStringArray(pythonPathResult.stdout),
-      );
     } catch (error) {
       if (error instanceof Error) {
         this.connection.window.showErrorMessage(error.message);


### PR DESCRIPTION
While internally ansible might add sys.path to the collection lookup
path, this is not something we want to expose to the user. We need
to be sure that the collection paths reported by out extension
info panel do match the output of `ansible --version`.
