### PR TITLE
Fix ansible lint config parsing

### DIFF
--- a/src/services/ansibleLint.ts
+++ b/src/services/ansibleLint.ts
@@ -180,10 +180,10 @@ export class AnsibleLint {
             };
 
             let severity: DiagnosticSeverity = DiagnosticSeverity.Error;
-            if (item.level) {
-              if (item.level === "error") {
+            if (item.severity) {
+              if (item.severity === "major") {
                 severity = DiagnosticSeverity.Error;
-              } else if (item.level === "warning") {
+              } else if (item.severity === "minor") {
                 severity = DiagnosticSeverity.Warning;
               }
             }

--- a/test/providers/validationProvider.test.ts
+++ b/test/providers/validationProvider.test.ts
@@ -82,7 +82,7 @@ function testAnsibleLintErrors(
       diagnosticReport: [
         {
           severity: 1,
-          message: "violates variable naming standards",
+          message: "Variables names",
           range: {
             start: { line: 4, character: 0 } as Position,
             end: {
@@ -99,6 +99,18 @@ function testAnsibleLintErrors(
             start: { line: 6, character: 0 } as Position,
             end: {
               line: 6,
+              character: integer.MAX_VALUE,
+            } as Position,
+          },
+          source: "ansible-lint",
+        },
+        {
+          severity: 1,
+          message: "Unsupported parameters",
+          range: {
+            start: { line: 14, character: 0 } as Position,
+            end: {
+              line: 14,
               character: integer.MAX_VALUE,
             } as Position,
           },


### PR DESCRIPTION
The PR:
1. updates keys based on the latest ansible-lint version.
2. Fixes: #569.
