### PR TITLE
Fix definition uri (#576)

### DIFF
--- a/src/providers/definitionProvider.ts
+++ b/src/providers/definitionProvider.ts
@@ -34,7 +34,7 @@ export async function getDefinition(
           const range = getOrigRange(node);
           return [
             {
-              targetUri: "file://" + module.source,
+              targetUri: `file://${  module.source}`,
               originSelectionRange: range
                 ? toLspRange(range, document)
                 : undefined,

--- a/src/providers/definitionProvider.ts
+++ b/src/providers/definitionProvider.ts
@@ -34,7 +34,7 @@ export async function getDefinition(
           const range = getOrigRange(node);
           return [
             {
-              targetUri: module.source,
+              targetUri: "file://" + module.source,
               originSelectionRange: range
                 ? toLspRange(range, document)
                 : undefined,


### PR DESCRIPTION
Returned URI should have a valid URI format, eg.:
file:///usr/lib/python3.11/site-packages/foo.py

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#basicJsonStructures

Fix #576 