### PR TITLE
Release v1.1.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,25 @@ Do *NOT* manually add changelog entries here! This file is updated by
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v1.1.0
+
+### Minor Changes
+
+- Update yaml to 2.x (#566) @priyamsahoo
+- Add variable auto-completion feature when cursor inside jinja inline brackets
+  (#552) @priyamsahoo
+
+### Bugfixes
+
+- Get module route for FQCN with more than 3 elements (#538) @fredericgiquel
+- Replace sphinx with mkdocs (#544) @ssbarnea
+- Modify package version info in meta-data (#530) @priyamsahoo
+- Fix intermittent EE test failures (#533) @ganeshrn
+- Fix github issue links in docs (#573) @antdking
+- Fix ansible lint config parsing (#577) @priyamsahoo
+- Add env variable to remove color from command result stdout (#579)
+  @priyamsahoo
+
 ## v1.0.4
 
 ### Bugfixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ansible/ansible-language-server",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ansible/ansible-language-server",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.20",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Ansible",
   "description": "Ansible language server",
   "license": "MIT",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "contributors": [
     {
       "name": "Tomasz Maciążek",


### PR DESCRIPTION
## v1.1.0

### Minor Changes

- Update yaml to 2.x (#566) @priyamsahoo
- Add variable auto-completion feature when cursor inside jinja inline brackets (#552) @priyamsahoo

### Bugfixes

- Get module route for FQCN with more than 3 elements (#538) @fredericgiquel
- Replace sphinx with mkdocs (#544) @ssbarnea
- Modify package version info in meta-data (#530) @priyamsahoo
- Fix intermittent EE test failures (#533) @ganeshrn
- Fix github issue links in docs (#573) @antdking
- Fix ansible lint config parsing (#577) @priyamsahoo
- Add env variable to remove color from command result stdout (#579) @priyamsahoo
