### PR TITLE
Fix vars completion in task files

### DIFF
--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -34,6 +34,7 @@ import {
   parseAllDocuments,
   getPossibleOptionsForPath,
   isCursorInsideJinjaBrackets,
+  isPlaybook,
 } from "../utils/yaml";
 import { getVarsCompletion } from "./completionProviderUtils";
 
@@ -51,13 +52,16 @@ const priorityMap = {
   choice: 2,
 };
 
-let DUMMY_MAPPING_CHARACTERS;
+let DUMMY_MAPPING_CHARACTERS: string;
+let IS_PLAYBOOK: boolean;
 
 export async function doCompletion(
   document: TextDocument,
   position: Position,
   context: WorkspaceFolderContext,
 ): Promise<CompletionItem[] | null> {
+  IS_PLAYBOOK = isPlaybook(document);
+
   let preparedText = document.getText();
   const offset = document.offsetAt(position);
 
@@ -217,8 +221,11 @@ export async function doCompletion(
         return completionItems;
       }
 
-      // Provide variable auto-completion if the cursor is inside valid jinja inline brackets
-      if (isCursorInsideJinjaBrackets(document, position, path)) {
+      // Provide variable auto-completion if the cursor is inside valid jinja inline brackets in a playbook
+      if (
+        IS_PLAYBOOK &&
+        isCursorInsideJinjaBrackets(document, position, path)
+      ) {
         const varCompletion: CompletionItem[] = getVarsCompletion(
           document.uri,
           path,

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -624,7 +624,7 @@ function firstElementOfList(document: TextDocument, nodeRange: Range): boolean {
   return elementsBeforeKey === "-";
 }
 
-function resolveSuffix(
+export function resolveSuffix(
   optionType: string,
   firstElementOfList: boolean,
   isDocPlaybook: boolean,

--- a/test/fixtures/completion/resolve_completion.yml
+++ b/test/fixtures/completion/resolve_completion.yml
@@ -8,7 +8,8 @@
       ansible.builtin.debug:
         msg: "Hello World {{ item }}"
 
-    - module_3:
+    - name: Collection module
+      module_3:
         opt_1:
           - sub_opt_1: Hello-world
             sub_opt_2:
@@ -18,7 +19,8 @@
               - sub_sub_opt_1:
                 sub_sub_opt_3:
                   - sub_sub_sub_opt_1:
-
+        
+    - name: Collection module with FQCN
       org_1.coll_1.module_1:
         opt_1:
           - sub_opt_1: Hello-world-2

--- a/test/fixtures/completion/resolve_completion.yml
+++ b/test/fixtures/completion/resolve_completion.yml
@@ -19,7 +19,7 @@
               - sub_sub_opt_1:
                 sub_sub_opt_3:
                   - sub_sub_sub_opt_1:
-        
+
     - name: Collection module with FQCN
       org_1.coll_1.module_1:
         opt_1:

--- a/test/providers/completionResolver.test.ts
+++ b/test/providers/completionResolver.test.ts
@@ -31,33 +31,41 @@ function testFQCNEnabled(context: WorkspaceFolderContext) {
           firstElementOfList: false,
         },
       },
-      completionText: "org_1.coll_3.module_3",
+      completionTextAtLineEnd: `org_1.coll_3.module_3:${EOL}\t`,
+      completionTextInBetween: "org_1.coll_3.module_3",
     },
   ];
 
-  tests.forEach(({ name, completionItem, completionText }) => {
-    it(`should resolve completion for ${name}`, async function () {
-      const actualCompletionResolveAtLineEnd = await doCompletionResolve(
-        completionItem,
-        context,
-      );
+  tests.forEach(
+    ({
+      name,
+      completionItem,
+      completionTextAtLineEnd,
+      completionTextInBetween,
+    }) => {
+      it(`should resolve completion for ${name}`, async function () {
+        const actualCompletionResolveAtLineEnd = await doCompletionResolve(
+          completionItem,
+          context,
+        );
 
-      expect(actualCompletionResolveAtLineEnd.insertText).be.equal(
-        `${completionText}:${EOL}\t`,
-      );
+        expect(actualCompletionResolveAtLineEnd.insertText).be.equal(
+          completionTextAtLineEnd,
+        );
 
-      // Check for completion resolution when asked in between of lines
-      completionItem.data.atEndOfLine = false;
-      const actualCompletionResolveAtInBetween = await doCompletionResolve(
-        completionItem,
-        context,
-      );
+        // Check for completion resolution when asked in between of lines
+        completionItem.data.atEndOfLine = false;
+        const actualCompletionResolveAtInBetween = await doCompletionResolve(
+          completionItem,
+          context,
+        );
 
-      expect(actualCompletionResolveAtInBetween.insertText).be.equal(
-        `${completionText}`,
-      );
-    });
-  });
+        expect(actualCompletionResolveAtInBetween.insertText).be.equal(
+          completionTextInBetween,
+        );
+      });
+    },
+  );
 }
 
 function testFQCNDisabled(context: WorkspaceFolderContext) {
@@ -74,7 +82,8 @@ function testFQCNDisabled(context: WorkspaceFolderContext) {
           firstElementOfList: false,
         },
       },
-      completionText: "module_3",
+      completionTextAtLineEnd: `module_3:${EOL}\t`,
+      completionTextInBetween: "module_3",
     },
     {
       name: "module name with full FQCN since it is not present in declared collections in playbook",
@@ -88,32 +97,40 @@ function testFQCNDisabled(context: WorkspaceFolderContext) {
           firstElementOfList: false,
         },
       },
-      completionText: "org_1.coll_1.module_1",
+      completionTextAtLineEnd: `org_1.coll_1.module_1:${EOL}\t`,
+      completionTextInBetween: "org_1.coll_1.module_1",
     },
   ];
-  tests.forEach(({ name, completionItem, completionText }) => {
-    it(`should resolve completion for ${name}`, async function () {
-      const actualCompletionResolveAtLineEnd = await doCompletionResolve(
-        completionItem,
-        context,
-      );
+  tests.forEach(
+    ({
+      name,
+      completionItem,
+      completionTextAtLineEnd,
+      completionTextInBetween,
+    }) => {
+      it(`should resolve completion for ${name}`, async function () {
+        const actualCompletionResolveAtLineEnd = await doCompletionResolve(
+          completionItem,
+          context,
+        );
 
-      expect(actualCompletionResolveAtLineEnd.insertText).be.equal(
-        `${completionText}:${EOL}\t`,
-      );
+        expect(actualCompletionResolveAtLineEnd.insertText).be.equal(
+          completionTextAtLineEnd,
+        );
 
-      // Check for completion resolution when asked in between of lines
-      completionItem.data.atEndOfLine = false;
-      const actualCompletionResolveAtInBetween = await doCompletionResolve(
-        completionItem,
-        context,
-      );
+        // Check for completion resolution when asked in between of lines
+        completionItem.data.atEndOfLine = false;
+        const actualCompletionResolveAtInBetween = await doCompletionResolve(
+          completionItem,
+          context,
+        );
 
-      expect(actualCompletionResolveAtInBetween.insertText).be.equal(
-        `${completionText}`,
-      );
-    });
-  });
+        expect(actualCompletionResolveAtInBetween.insertText).be.equal(
+          completionTextInBetween,
+        );
+      });
+    },
+  );
 }
 
 function testResolveModuleOptionCompletion(context: WorkspaceFolderContext) {
@@ -129,7 +146,8 @@ function testResolveModuleOptionCompletion(context: WorkspaceFolderContext) {
           firstElementOfList: true,
         },
       },
-      completionText: "opt_1",
+      completionTextAtLineEnd: `opt_1:${EOL}\t\t`,
+      completionTextInBetween: "opt_1",
     },
     {
       name: "sub option expecting list with `sub_option: ${EOL}\\t- `",
@@ -141,7 +159,8 @@ function testResolveModuleOptionCompletion(context: WorkspaceFolderContext) {
           atEndOfLine: true,
         },
       },
-      completionText: "sub_opt_2",
+      completionTextAtLineEnd: `sub_opt_2:${EOL}\t- `,
+      completionTextInBetween: "sub_opt_2",
     },
     {
       name: "sub option expecting string or number or boolean with `sub_option: `",
@@ -153,49 +172,41 @@ function testResolveModuleOptionCompletion(context: WorkspaceFolderContext) {
           atEndOfLine: true,
         },
       },
-      completionText: "sub_opt_1",
+      completionTextAtLineEnd: "sub_opt_1: ",
+      completionTextInBetween: "sub_opt_1",
     },
   ];
 
-  tests.forEach(({ name, completionItem, completionText }) => {
-    it(`should resolve completion for ${name}`, async function () {
-      const actualCompletionResolveAtLineEnd = await doCompletionResolve(
-        completionItem,
-        context,
-      );
+  tests.forEach(
+    ({
+      name,
+      completionItem,
+      completionTextAtLineEnd,
+      completionTextInBetween,
+    }) => {
+      it(`should resolve completion for ${name}`, async function () {
+        const actualCompletionResolveAtLineEnd = await doCompletionResolve(
+          completionItem,
+          context,
+        );
 
-      let returnSuffix: string;
-      switch (completionItem.data.type) {
-        case "list":
-          returnSuffix = completionItem.data.firstElementOfList
-            ? `${EOL}\t\t- `
-            : `${EOL}\t- `;
-          break;
-        case "dict":
-          returnSuffix = completionItem.data.firstElementOfList
-            ? `${EOL}\t\t`
-            : `${EOL}\t`;
-          break;
-        default:
-          returnSuffix = " ";
-          break;
-      }
-      expect(actualCompletionResolveAtLineEnd.insertText).be.equal(
-        `${completionText}:${returnSuffix}`,
-      );
+        expect(actualCompletionResolveAtLineEnd.insertText).be.equal(
+          completionTextAtLineEnd,
+        );
 
-      // Check for completion resolution when asked in between of lines
-      completionItem.data.atEndOfLine = false;
-      const actualCompletionResolveAtInBetween = await doCompletionResolve(
-        completionItem,
-        context,
-      );
+        // Check for completion resolution when asked in between of lines
+        completionItem.data.atEndOfLine = false;
+        const actualCompletionResolveAtInBetween = await doCompletionResolve(
+          completionItem,
+          context,
+        );
 
-      expect(actualCompletionResolveAtInBetween.insertText).be.equal(
-        `${completionText}`,
-      );
-    });
-  });
+        expect(actualCompletionResolveAtInBetween.insertText).be.equal(
+          completionTextInBetween,
+        );
+      });
+    },
+  );
 }
 
 describe("doCompletionResolve()", () => {
@@ -208,57 +219,61 @@ describe("doCompletionResolve()", () => {
   const docSettings = context.documentSettings.get(textDoc.uri);
 
   describe("Resolve completion for module names", () => {
-    describe("With useFQCN enabled and with EE enabled @ee", () => {
-      before(async () => {
-        setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
-        );
-        await enableExecutionEnvironmentSettings(docSettings);
-      });
-      testFQCNEnabled(context);
+    describe("Resolve completion for module names when FQCN is enabled", function () {
+      describe("with EE enabled @ee", () => {
+        before(async () => {
+          setFixtureAnsibleCollectionPathEnv(
+            "/home/runner/.ansible/collections:/usr/share/ansible",
+          );
+          await enableExecutionEnvironmentSettings(docSettings);
+        });
+        testFQCNEnabled(context);
 
-      after(async () => {
-        setFixtureAnsibleCollectionPathEnv();
-        await disableExecutionEnvironmentSettings(docSettings);
+        after(async () => {
+          setFixtureAnsibleCollectionPathEnv();
+          await disableExecutionEnvironmentSettings(docSettings);
+        });
       });
-    });
 
-    describe("With useFQCN enabled and with EE disabled", () => {
-      before(async () => {
-        setFixtureAnsibleCollectionPathEnv();
-        await disableExecutionEnvironmentSettings(docSettings);
-      });
-      testFQCNEnabled(context);
-    });
-
-    describe("With useFQCN disabled and with EE enabled @ee", () => {
-      before(async () => {
-        setFixtureAnsibleCollectionPathEnv(
-          "/home/runner/.ansible/collections:/usr/share/ansible",
-        );
-        await enableExecutionEnvironmentSettings(docSettings);
-        (await docSettings).ansible.useFullyQualifiedCollectionNames = false;
-      });
-      testFQCNDisabled(context);
-
-      after(async () => {
-        setFixtureAnsibleCollectionPathEnv();
-        await disableExecutionEnvironmentSettings(docSettings);
-        (await docSettings).ansible.useFullyQualifiedCollectionNames = true;
+      describe("with EE disabled", () => {
+        before(async () => {
+          setFixtureAnsibleCollectionPathEnv();
+          await disableExecutionEnvironmentSettings(docSettings);
+        });
+        testFQCNEnabled(context);
       });
     });
 
-    describe("With useFQCN disabled and with EE disabled", () => {
-      before(async () => {
-        setFixtureAnsibleCollectionPathEnv();
-        await disableExecutionEnvironmentSettings(docSettings);
-        (await docSettings).ansible.useFullyQualifiedCollectionNames = false;
-      });
-      testFQCNDisabled(context);
+    describe("Resolve completion for module names when FQCN is disabled", function () {
+      describe("with EE enabled @ee", () => {
+        before(async () => {
+          setFixtureAnsibleCollectionPathEnv(
+            "/home/runner/.ansible/collections:/usr/share/ansible",
+          );
+          await enableExecutionEnvironmentSettings(docSettings);
+          (await docSettings).ansible.useFullyQualifiedCollectionNames = false;
+        });
+        testFQCNDisabled(context);
 
-      after(async () => {
-        setFixtureAnsibleCollectionPathEnv();
-        (await docSettings).ansible.useFullyQualifiedCollectionNames = true;
+        after(async () => {
+          setFixtureAnsibleCollectionPathEnv();
+          await disableExecutionEnvironmentSettings(docSettings);
+          (await docSettings).ansible.useFullyQualifiedCollectionNames = true;
+        });
+      });
+
+      describe("with EE disabled", () => {
+        before(async () => {
+          setFixtureAnsibleCollectionPathEnv();
+          await disableExecutionEnvironmentSettings(docSettings);
+          (await docSettings).ansible.useFullyQualifiedCollectionNames = false;
+        });
+        testFQCNDisabled(context);
+
+        after(async () => {
+          setFixtureAnsibleCollectionPathEnv();
+          (await docSettings).ansible.useFullyQualifiedCollectionNames = true;
+        });
       });
     });
   });

--- a/test/utils/resolveSuffixWhileCompletion.test.ts
+++ b/test/utils/resolveSuffixWhileCompletion.test.ts
@@ -1,0 +1,87 @@
+import { EOL } from "os";
+import { resolveSuffix } from "../../src/providers/completionProvider";
+import { expect } from "chai";
+
+function testResolveSuffixInPlaybook() {
+  const tests = [
+    {
+      optionType: "dict",
+      firstElementOfList: true,
+      isPlaybook: true,
+      expectedSuffix: `${EOL}\t\t`,
+    },
+    {
+      optionType: "list",
+      firstElementOfList: true,
+      isPlaybook: true,
+      expectedSuffix: `${EOL}\t\t- `,
+    },
+    {
+      optionType: "string",
+      firstElementOfList: true,
+      isPlaybook: true,
+      expectedSuffix: " ",
+    },
+  ];
+
+  tests.forEach(
+    ({ optionType, firstElementOfList, isPlaybook, expectedSuffix }) => {
+      it(`should provide suffix for '${optionType}' type options in a playbook`, function () {
+        const actualSuffix = resolveSuffix(
+          optionType,
+          firstElementOfList,
+          isPlaybook,
+        );
+
+        expect(actualSuffix).to.equal(expectedSuffix);
+      });
+    },
+  );
+}
+
+function testResolveSuffixInNonPlaybookFile() {
+  const tests = [
+    {
+      optionType: "dict",
+      firstElementOfList: true,
+      isPlaybook: false,
+      expectedSuffix: `${EOL}\t`,
+    },
+    {
+      optionType: "list",
+      firstElementOfList: true,
+      isPlaybook: false,
+      expectedSuffix: `${EOL}\t- `,
+    },
+    {
+      optionType: "string",
+      firstElementOfList: true,
+      isPlaybook: false,
+      expectedSuffix: " ",
+    },
+  ];
+
+  tests.forEach(
+    ({ optionType, firstElementOfList, isPlaybook, expectedSuffix }) => {
+      it(`should provide suffix for '${optionType}' type options in a non-playbook file`, function () {
+        const actualSuffix = resolveSuffix(
+          optionType,
+          firstElementOfList,
+          isPlaybook,
+        );
+
+        expect(actualSuffix).to.equal(expectedSuffix);
+      });
+    },
+  );
+}
+
+describe("resolveSuffix", function () {
+  describe("Resolve suffix for completion items in a playbook", function () {
+    testResolveSuffixInPlaybook();
+  });
+
+  describe("Resolve suffix for completion items in a non-playbook file", function () {
+    testResolveSuffixInNonPlaybookFile();
+  });
+});


### PR DESCRIPTION
The PR:
1. Fixes the issue of ls being stuck when asked for vars completion in a task file (Resolves: #587).
2. Fixes extra indentation issue when module completion is resolved.