### PR TITLE
Release v1.2.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,19 @@ Do *NOT* manually add changelog entries here! This file is updated by
 
 <!-- KEEP-THIS-COMMENT -->
 
+## v1.2.0
+
+### Minor Changes
+
+- Add support for playbook adjacent collections (#511) @priyamsahoo
+- Use antsibull-docs-ts to render semantic markup (#563) @felixfontein
+
+### Bugfixes
+
+- Fix isPlaybook method (#590) @priyamsahoo
+- Fix vars completion in task files (#589) @priyamsahoo
+- Return URI instead of filepath (#560) @ajinkyau
+
 ## v1.1.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ansible/ansible-language-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ansible/ansible-language-server",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@flatten-js/interval-tree": "^1.0.20",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Ansible",
   "description": "Ansible language server",
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "contributors": [
     {
       "name": "Tomasz Maciążek",


### PR DESCRIPTION
## v1.2.0

### Minor Changes

- Add support for playbook adjacent collections (#511) @priyamsahoo
- Use antsibull-docs-ts to render semantic markup (#563) @felixfontein

### Bugfixes

- Fix isPlaybook method (#590) @priyamsahoo
- Fix vars completion in task files (#589) @priyamsahoo
- Return URI instead of filepath (#560) @ajinkyau
