### PR TITLE
Improve test-setup.sh for macos

### DIFF
--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -176,13 +176,29 @@ fi
 # shellcheck disable=SC1091
 . "${VIRTUAL_ENV}/bin/activate"
 
+if [[ "$(which python3)" != ${VIRTUAL_ENV}/bin/python3 ]]; then
+    log warning "Virtualenv broken, trying to recreate it ..."
+    python3 -m venv --clear "${VIRTUAL_ENV}"
+    . "${VIRTUAL_ENV}/bin/activate"
+    if [[ "$(which python3)" != ${VIRTUAL_ENV}/bin/python3 ]]; then
+        log error "Virtualenv still broken."
+        exit 99
+    fi
+fi
 log notice "Upgrading pip ..."
+
 python3 -m pip install -q -U pip
 
 EE_VERSION=$(./tools/get-image-version)
 if [[ $(uname || true) != MINGW* ]]; then # if we are not on pure Windows
     URL="https://raw.githubusercontent.com/ansible/creator-ee/${EE_VERSION}/_build/requirements.txt"
     log notice "Installing dependencies from .config/requirements.in and ${URL} loaded from .config/Containerfile ..."
+
+    if [[ "${OS:-}" == "darwin" ]]; then
+        log notice "MacOS detected, altering CFLAGS to avoid potential build failure due to https://github.com/ansible/pylibssh/issues/207 ..."
+        CFLAGS="-I $(brew --prefix)/include -I ext -L $(brew --prefix)/lib -lssh"
+        export CFLAGS
+    fi
     python3 -m pip install -r "${URL}" -r .config/requirements.in
 fi
 


### PR DESCRIPTION
- discover broken virtualens (after python upgrade)
- implement workaround for building ansible-pylibssh

Related: https://github.com/ansible/pylibssh/issues/207
