### PR TITLE
Change testing python to 3.10

### DIFF
--- a/.github/workflows/task.yml
+++ b/.github/workflows/task.yml
@@ -106,6 +106,12 @@ jobs:
             qemu-user-static
             xvfb
 
+      - name: Set up Python ${{ matrix.python_version || '3.10' }}
+        if: "!contains(matrix.shell, 'wsl')"
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python_version || '3.10' }}
+
       - name: Enable caching
         if: "!contains(matrix.shell, 'wsl')"
         uses: actions/cache@v4


### PR DESCRIPTION
Changed python used for testing from 3.9 to 3.10 for all environments other than WSL. Under WSL we only have 3.9 for now.