### PR TITLE
increase the maxBuffer to avoid truncated process stdout resulting in truncated/invalid JSON results (ie. ansible-lint)

### DIFF
--- a/src/utils/commandRunner.ts
+++ b/src/utils/commandRunner.ts
@@ -69,6 +69,7 @@ export class CommandRunner {
       encoding: "utf-8",
       cwd: currentWorkingDirectory,
       env: runEnv,
+      maxBuffer: 10 * 1000 * 1000,
     });
 
     return result;


### PR DESCRIPTION
My `ansible-lint` resulting JSON document report is very large, therefore exceeding the I/O buffer and is truncated and could not be parsed (invalid json), see the error below:

Could not parse ansible-lint output. Please check your ansible-lint installation & configuration. More info in `Ansible Server` output.:
Type number and <Enter> or click with the mouse (q or empty cancels):

This issue could be solved by increasing the maxBuffer property in the `src/utils/commandRunner.ts` file:

    const result = await asyncExec(command, {
      encoding: "utf-8",
      cwd: currentWorkingDirectory,
      env: runEnv,
+      maxBuffer: 10 * 1000 * 1000,
    });
