### PR TITLE
Update README.md with links to vscode-ansible docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Ansible Language Server
 
-🚧 The Ansible Language Server codebase is now included in the Ansible VS Code Extension ([vscode-ansible](https://github.com/ansible/vscode-ansible)) repository.
+🚧 The Ansible Language Server codebase is now included in the Ansible VS Code
+Extension ([vscode-ansible](https://github.com/ansible/vscode-ansible))
+repository.
 
-Documentation for the extension can be found at [ansible.readthedocs.io/projects/vscode-ansible/](https://ansible.readthedocs.io/projects/vscode-ansible/).
+Documentation for the extension can be found at
+[ansible.readthedocs.io/projects/vscode-ansible/](https://ansible.readthedocs.io/projects/vscode-ansible/).

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Extension ([vscode-ansible](https://github.com/ansible/vscode-ansible))
 repository.
 
 The Ansible Language Server README is located
-[here](https://github.com/ansible/vscode-ansible/blob/main/docs/als/README.md),
-in the vscode-ansible repository.
+[here](https://github.com/ansible/vscode-ansible/blob/main/docs/als/README.md).
 
 Documentation for the extension can be found at
 [ansible.readthedocs.io/projects/vscode-ansible/](https://ansible.readthedocs.io/projects/vscode-ansible/).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 🚧 The Ansible Language Server codebase is now included in the Ansible VS Code
 Extension ([vscode-ansible](https://github.com/ansible/vscode-ansible))
-repository. 
+repository.
 
-The Ansible Language Server README is located [here](https://github.com/ansible/vscode-ansible/blob/main/docs/als/README.md), in the vscode-ansible repository. 
+The Ansible Language Server README is located
+[here](https://github.com/ansible/vscode-ansible/blob/main/docs/als/README.md),
+in the vscode-ansible repository.
 
 Documentation for the extension can be found at
 [ansible.readthedocs.io/projects/vscode-ansible/](https://ansible.readthedocs.io/projects/vscode-ansible/).

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ repository.
 The Ansible Language Server README is located
 [here](https://github.com/ansible/vscode-ansible/blob/main/docs/als/README.md).
 
-Documentation for the extension can be found at
-[ansible.readthedocs.io/projects/vscode-ansible/](https://ansible.readthedocs.io/projects/vscode-ansible/).
+Documentation for the Ansible Language Server can be found at
+[ansible.readthedocs.io/projects/vscode-ansible/als](https://ansible.readthedocs.io/projects/vscode-ansible/als/).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 🚧 The Ansible Language Server codebase is now included in the Ansible VS Code
 Extension ([vscode-ansible](https://github.com/ansible/vscode-ansible))
-repository.
+repository. 
+
+The Ansible Language Server README is located [here](https://github.com/ansible/vscode-ansible/blob/main/docs/als/README.md), in the vscode-ansible repository. 
 
 Documentation for the extension can be found at
 [ansible.readthedocs.io/projects/vscode-ansible/](https://ansible.readthedocs.io/projects/vscode-ansible/).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ansible Language Server
 
-Documentation for Ansible Language Server can be found at
-[als.readthedocs.io](https://als.readthedocs.io/).
+🚧 The Ansible Language Server codebase is now included in the Ansible VS Code Extension ([vscode-ansible](https://github.com/ansible/vscode-ansible)) repository.
+
+Documentation for the extension can be found at [ansible.readthedocs.io/projects/vscode-ansible/](https://ansible.readthedocs.io/projects/vscode-ansible/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,8 +62,8 @@ improve the user experience:
 - on module options, the required properties are shown first, and aliases are
   shown last, otherwise ordering from the documentation is preserved
 - FQCNs (fully qualified collection names) are inserted only when necessary;
-  collections configured with the [`collections` keyword] are honored. This
-  behavior can be disabled in extension settings.
+  collections configured with the [`collections` keyword] are honored. This behavior
+  can be disabled in extension settings.
 
 [`collections` keyword]:
   https://docs.ansible.com/ansible/latest/collections_guide/collections_using_playbooks.html#simplifying-module-names-with-the-collections-keyword


### PR DESCRIPTION
Updating the README with the appropriate information and links, pointing to the vscode-ansible codebase. 